### PR TITLE
Refactor DML with Robust Design Patterns

### DIFF
--- a/crates/tsql_core/src/executor/cte.rs
+++ b/crates/tsql_core/src/executor/cte.rs
@@ -42,12 +42,14 @@ pub fn resolve_cte_table<'a>(
 pub fn cte_to_context_rows(cte: &CteTable, alias: &str) -> Vec<crate::executor::model::JoinedRow> {
     cte.rows
         .iter()
-        .filter(|r| !r.deleted)
-        .map(|row| {
+        .enumerate()
+        .filter(|(_, r)| !r.deleted)
+        .map(|(i, row)| {
             vec![crate::executor::model::ContextTable {
                 table: cte.table_def.clone(),
                 alias: alias.to_string(),
                 row: Some(row.clone()),
+                storage_index: Some(i),
             }]
         })
         .collect()

--- a/crates/tsql_core/src/executor/joins.rs
+++ b/crates/tsql_core/src/executor/joins.rs
@@ -78,6 +78,7 @@ fn apply_join_left(
                 table: right.table.clone(),
                 alias: right.alias.clone(),
                 row: None,
+                storage_index: None,
             });
             next_rows.push(candidate);
         }
@@ -121,6 +122,7 @@ fn apply_join_right(
                     table,
                     alias,
                     row: None,
+                    storage_index: None,
                 }];
                 candidate.extend(right_row.clone());
                 next_rows.push(candidate);
@@ -164,6 +166,7 @@ fn apply_join_full(
                 table: right.table.clone(),
                 alias: right.alias.clone(),
                 row: None,
+                storage_index: None,
             });
             next_rows.push(candidate);
         }
@@ -180,6 +183,7 @@ fn apply_join_full(
                     table: table.clone(),
                     alias: alias.clone(),
                     row: None,
+                    storage_index: None,
                 }];
                 candidate.extend(right_rows[ri].clone());
                 next_rows.push(candidate);

--- a/crates/tsql_core/src/executor/model.rs
+++ b/crates/tsql_core/src/executor/model.rs
@@ -20,6 +20,7 @@ pub struct ContextTable {
     pub table: TableDef,
     pub alias: String,
     pub row: Option<StoredRow>,
+    pub storage_index: Option<usize>,
 }
 
 pub type JoinedRow = Vec<ContextTable>;
@@ -29,5 +30,6 @@ pub(crate) fn single_row_context(table: &TableDef, row: StoredRow) -> JoinedRow 
         table: table.clone(),
         alias: table.name.clone(),
         row: Some(row),
+        storage_index: None,
     }]
 }

--- a/crates/tsql_core/src/executor/mutation/delete.rs
+++ b/crates/tsql_core/src/executor/mutation/delete.rs
@@ -1,13 +1,14 @@
-use crate::ast::{DeleteStmt, FromClause, JoinType};
-use crate::catalog::TableDef;
+use std::collections::HashSet;
+
+use crate::ast::{DeleteStmt, SelectItem, SelectStmt};
 use crate::error::DbError;
-use crate::storage::StoredRow;
 
 use super::super::context::ExecutionContext;
-use super::super::evaluator::eval_predicate;
-use super::super::model::single_row_context;
+use super::super::query::QueryExecutor;
+use super::super::result::QueryResult;
 
 use super::MutationExecutor;
+use super::output::build_output_result;
 use super::validation::enforce_foreign_keys_on_delete;
 
 impl<'a> MutationExecutor<'a> {
@@ -15,7 +16,7 @@ impl<'a> MutationExecutor<'a> {
         &mut self,
         mut stmt: DeleteStmt,
         ctx: &mut ExecutionContext,
-    ) -> Result<(), DbError> {
+    ) -> Result<Option<QueryResult>, DbError> {
         if let Some(mapped) = ctx.resolve_table_name(&stmt.table.name) {
             stmt.table.name = mapped;
             if stmt.table.schema.is_none() {
@@ -34,180 +35,70 @@ impl<'a> MutationExecutor<'a> {
             .clone();
 
         let table_id = table.id;
-        let mut rows = self.storage.get_rows(table_id)?;
 
-        if let Some(from_clause) = &stmt.from {
-            return self.execute_delete_with_from(
-                &table, table_id, &mut rows, &stmt, from_clause, ctx,
-            );
-        }
+        let query_stmt = SelectStmt {
+            from: stmt.from.as_ref().and_then(|f| f.tables.get(0).cloned()).or_else(|| {
+                Some(crate::ast::TableRef {
+                    name: stmt.table.clone(),
+                    alias: None,
+                })
+            }),
+            joins: stmt.from.as_ref().map(|f| f.joins.clone()).unwrap_or_default(),
+            applies: vec![],
+            projection: vec![SelectItem {
+                expr: crate::ast::Expr::Wildcard,
+                alias: None,
+            }],
+            distinct: false,
+            top: None,
+            selection: stmt.selection.clone(),
+            group_by: vec![],
+            having: None,
+            order_by: vec![],
+            offset: None,
+            fetch: None,
+        };
 
-        for (i, row) in rows.iter_mut().enumerate() {
-            if row.deleted {
-                continue;
-            }
-            let joined = single_row_context(&table, row.clone());
-            let matches = if let Some(selection) = &stmt.selection {
-                eval_predicate(
-                    selection,
-                    &joined,
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?
-            } else {
-                true
-            };
-            if matches {
-                enforce_foreign_keys_on_delete(&table, self.catalog, self.storage, row)?;
-                self.storage.delete_row(table_id, i)?;
-            }
-        }
+        let query_executor = QueryExecutor {
+            catalog: self.catalog,
+            storage: self.storage,
+            clock: self.clock,
+        };
 
-        Ok(())
-    }
+        let joined_rows = query_executor.execute_to_joined_rows(query_stmt, ctx)?;
 
-    fn execute_delete_with_from(
-        &mut self,
-        table: &TableDef,
-        table_id: u32,
-        rows: &mut Vec<StoredRow>,
-        stmt: &DeleteStmt,
-        from_clause: &FromClause,
-        ctx: &mut ExecutionContext,
-    ) -> Result<(), DbError> {
-        let mut delete_indices = Vec::new();
+        let mut deleted_indices = HashSet::new();
+        let mut deleted_rows_for_output = Vec::new();
 
-        for i in 0..rows.len() {
-            if rows[i].deleted {
-                continue;
-            }
+        for joined_row in joined_rows {
+            let target_ctx = joined_row
+                .iter()
+                .find(|ct| ct.table.id == table_id)
+                .ok_or_else(|| DbError::Execution("target table not found in join context".into()))?;
 
-            let mut combined_ctx: super::super::model::JoinedRow =
-                single_row_context(table, rows[i].clone());
-
-            let mut all_match = true;
-            for from_table_ref in &from_clause.tables {
-                let resolved_name = ctx
-                    .resolve_table_name(&from_table_ref.name.name)
-                    .unwrap_or_else(|| from_table_ref.name.name.clone());
-                let from_schema = from_table_ref.name.schema_or_dbo();
-                let from_table = self
-                    .catalog
-                    .find_table(from_schema, &resolved_name)
-                    .ok_or_else(|| {
-                        DbError::Semantic(format!(
-                            "table '{}.{}' not found",
-                            from_schema, resolved_name
-                        ))
-                    })?
-                    .clone();
-                let from_rows = self.storage.get_rows(from_table.id)?;
-                let non_deleted: Vec<_> = from_rows.iter().filter(|r| !r.deleted).collect();
-                if non_deleted.is_empty() {
-                    all_match = false;
-                    break;
-                }
-                let alias = from_table_ref
-                    .alias
-                    .clone()
-                    .unwrap_or_else(|| resolved_name.clone());
-                combined_ctx.push(super::super::model::ContextTable {
-                    table: from_table.clone(),
-                    alias: alias.clone(),
-                    row: Some(non_deleted[0].clone()),
-                });
-            }
-
-            if !all_match {
-                continue;
-            }
-
-            for join_clause in &from_clause.joins {
-                let resolved_name = ctx
-                    .resolve_table_name(&join_clause.table.name.name)
-                    .unwrap_or_else(|| join_clause.table.name.name.clone());
-                let join_schema = join_clause.table.name.schema_or_dbo();
-                let join_table = self
-                    .catalog
-                    .find_table(join_schema, &resolved_name)
-                    .ok_or_else(|| {
-                        DbError::Semantic(format!(
-                            "table '{}.{}' not found",
-                            join_schema, resolved_name
-                        ))
-                    })?
-                    .clone();
-                let join_rows = self.storage.get_rows(join_table.id)?;
-
-                let mut found_match = false;
-                let alias = join_clause
-                    .table
-                    .alias
-                    .clone()
-                    .unwrap_or_else(|| resolved_name.clone());
-                for join_row in join_rows.iter().filter(|r| !r.deleted) {
-                    let mut test_ctx = combined_ctx.clone();
-                    test_ctx.push(super::super::model::ContextTable {
-                        table: join_table.clone(),
-                        alias: alias.clone(),
-                        row: Some(join_row.clone()),
-                    });
-                    if let Some(ref on_expr) = join_clause.on {
-                        if eval_predicate(
-                            on_expr,
-                            &test_ctx,
-                            ctx,
-                            self.catalog,
-                            self.storage,
-                            self.clock,
-                        )? {
-                            combined_ctx = test_ctx;
-                            found_match = true;
-                            break;
-                        }
+            if let (Some(stored_row), Some(idx)) = (&target_ctx.row, target_ctx.storage_index) {
+                if !deleted_indices.contains(&idx) {
+                    enforce_foreign_keys_on_delete(&table, self.catalog, self.storage, stored_row)?;
+                    deleted_indices.insert(idx);
+                    if stmt.output.is_some() {
+                        deleted_rows_for_output.push(stored_row.clone());
                     }
                 }
-                match join_clause.join_type {
-                    JoinType::Inner => {
-                        if !found_match {
-                            all_match = false;
-                            break;
-                        }
-                    }
-                    JoinType::Left => {}
-                    _ => {}
-                }
-            }
-
-            if !all_match {
-                continue;
-            }
-
-            let matches = if let Some(selection) = &stmt.selection {
-                eval_predicate(
-                    selection,
-                    &combined_ctx,
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?
-            } else {
-                true
-            };
-
-            if matches {
-                delete_indices.push(i);
             }
         }
 
-        for &idx in &delete_indices {
-            enforce_foreign_keys_on_delete(table, self.catalog, self.storage, &rows[idx])?;
+        let mut indices_to_delete: Vec<usize> = deleted_indices.into_iter().collect();
+        indices_to_delete.sort_unstable_by(|a, b| b.cmp(a));
+
+        for idx in indices_to_delete {
             self.storage.delete_row(table_id, idx)?;
         }
 
-        Ok(())
+        if let Some(output) = stmt.output {
+            let output_rows: Vec<&crate::storage::StoredRow> = deleted_rows_for_output.iter().collect();
+            return build_output_result(&output, &table, &[], &output_rows);
+        }
+
+        Ok(None)
     }
 }

--- a/crates/tsql_core/src/executor/mutation/insert.rs
+++ b/crates/tsql_core/src/executor/mutation/insert.rs
@@ -7,8 +7,10 @@ use crate::types::{DataType, Value};
 use super::super::context::ExecutionContext;
 use super::super::evaluator::eval_expr_to_type_constant;
 use super::super::model::single_row_context;
+use super::super::result::QueryResult;
 
 use super::MutationExecutor;
+use super::output::build_output_result;
 use super::validation::{
     enforce_checks_on_row, enforce_foreign_keys_on_insert, enforce_string_length,
     enforce_unique_on_insert,
@@ -19,7 +21,7 @@ impl<'a> MutationExecutor<'a> {
         &mut self,
         mut stmt: InsertStmt,
         ctx: &mut ExecutionContext,
-    ) -> Result<(), DbError> {
+    ) -> Result<Option<QueryResult>, DbError> {
         if let Some(mapped) = ctx.resolve_table_name(&stmt.table.name) {
             stmt.table.name = mapped;
             if stmt.table.schema.is_none() {
@@ -38,14 +40,15 @@ impl<'a> MutationExecutor<'a> {
             .clone();
 
         let table_id = table.id;
+        let mut inserted_rows_for_output = Vec::new();
 
         if stmt.default_values {
             let row = self.build_insert_row(&table, &[], vec![], ctx)?;
-            self.storage.insert_row(table_id, row)?;
-            return Ok(());
-        }
-
-        let insert_columns = if let Some(cols) = stmt.columns.clone() {
+            self.storage.insert_row(table_id, row.clone())?;
+            if stmt.output.is_some() {
+                inserted_rows_for_output.push(row);
+            }
+        } else if let Some(select_stmt) = stmt.select_source {
             cols
         } else {
             table
@@ -56,13 +59,23 @@ impl<'a> MutationExecutor<'a> {
                 .collect::<Vec<_>>()
         };
 
-        if let Some(select_stmt) = stmt.select_source {
             let query_result = super::super::query::QueryExecutor {
                 catalog: self.catalog as &dyn Catalog,
                 storage: self.storage,
                 clock: self.clock,
             }
             .execute_select(*select_stmt, ctx)?;
+
+            let insert_columns = if let Some(cols) = stmt.columns.clone() {
+                cols
+            } else {
+                table
+                    .columns
+                    .iter()
+                    .filter(|c| c.computed_expr.is_none())
+                    .map(|c| c.name.clone())
+                    .collect::<Vec<_>>()
+            };
 
             if insert_columns.len() != query_result.columns.len() {
                 return Err(DbError::Execution(format!(
@@ -110,20 +123,41 @@ impl<'a> MutationExecutor<'a> {
                     self.storage,
                     self.clock,
                 )?;
-                self.storage.insert_row(table_id, temp_row)?;
+                self.storage.insert_row(table_id, temp_row.clone())?;
+                if stmt.output.is_some() {
+                    inserted_rows_for_output.push(temp_row);
+                }
             }
-            return Ok(());
+        } else {
+            let insert_columns = if let Some(cols) = stmt.columns.clone() {
+                cols
+            } else {
+                table
+                    .columns
+                    .iter()
+                    .filter(|c| c.computed_expr.is_none())
+                    .map(|c| c.name.clone())
+                    .collect::<Vec<_>>()
+            };
+
+            for value_row in stmt.values {
+                let row = self.build_insert_row(&table, &insert_columns, value_row, ctx)?;
+                enforce_unique_on_insert(&table, self.storage, table_id, &row)?;
+                enforce_foreign_keys_on_insert(&table, self.catalog, self.storage, &row)?;
+                enforce_checks_on_row(&table, &row, ctx, self.catalog, self.storage, self.clock)?;
+                self.storage.insert_row(table_id, row.clone())?;
+                if stmt.output.is_some() {
+                    inserted_rows_for_output.push(row);
+                }
+            }
         }
 
-        for value_row in stmt.values {
-            let row = self.build_insert_row(&table, &insert_columns, value_row, ctx)?;
-            enforce_unique_on_insert(&table, self.storage, table_id, &row)?;
-            enforce_foreign_keys_on_insert(&table, self.catalog, self.storage, &row)?;
-            enforce_checks_on_row(&table, &row, ctx, self.catalog, self.storage, self.clock)?;
-            self.storage.insert_row(table_id, row)?;
+        if let Some(output) = stmt.output {
+            let inserted: Vec<&crate::storage::StoredRow> = inserted_rows_for_output.iter().collect();
+            return build_output_result(&output, &table, &inserted, &[]);
         }
 
-        Ok(())
+        Ok(None)
     }
 
     pub(crate) fn build_insert_row(

--- a/crates/tsql_core/src/executor/mutation/update.rs
+++ b/crates/tsql_core/src/executor/mutation/update.rs
@@ -1,13 +1,14 @@
-use crate::ast::{FromClause, JoinType, UpdateStmt};
-use crate::catalog::TableDef;
+use std::collections::HashSet;
+
+use crate::ast::{SelectItem, SelectStmt, UpdateStmt};
 use crate::error::DbError;
-use crate::storage::StoredRow;
 
 use super::super::context::ExecutionContext;
-use super::super::evaluator::eval_predicate;
-use super::super::model::single_row_context;
+use super::super::query::QueryExecutor;
+use super::super::result::QueryResult;
 
 use super::MutationExecutor;
+use super::output::build_output_result;
 use super::validation::{
     apply_assignments, enforce_checks_on_row, enforce_foreign_keys_on_delete,
     enforce_foreign_keys_on_insert, enforce_unique_on_update, validate_row_against_table,
@@ -18,7 +19,7 @@ impl<'a> MutationExecutor<'a> {
         &mut self,
         mut stmt: UpdateStmt,
         ctx: &mut ExecutionContext,
-    ) -> Result<(), DbError> {
+    ) -> Result<Option<QueryResult>, DbError> {
         if let Some(mapped) = ctx.resolve_table_name(&stmt.table.name) {
             stmt.table.name = mapped;
             if stmt.table.schema.is_none() {
@@ -37,228 +38,91 @@ impl<'a> MutationExecutor<'a> {
             .clone();
 
         let table_id = table.id;
-        let mut rows = self.storage.get_rows(table_id)?;
 
-        if let Some(from_clause) = &stmt.from {
-            return self.execute_update_with_from(
-                &table, table_id, &mut rows, &stmt, from_clause, ctx,
-            );
-        }
+        let query_stmt = SelectStmt {
+            from: stmt.from.as_ref().and_then(|f| f.tables.get(0).cloned()).or_else(|| {
+                Some(crate::ast::TableRef {
+                    name: stmt.table.clone(),
+                    alias: None,
+                })
+            }),
+            joins: stmt.from.as_ref().map(|f| f.joins.clone()).unwrap_or_default(),
+            applies: vec![],
+            projection: vec![SelectItem {
+                expr: crate::ast::Expr::Wildcard,
+                alias: None,
+            }],
+            distinct: false,
+            top: None,
+            selection: stmt.selection.clone(),
+            group_by: vec![],
+            having: None,
+            order_by: vec![],
+            offset: None,
+            fetch: None,
+        };
 
-        let mut updated_indices = Vec::new();
-        for i in 0..rows.len() {
-            if rows[i].deleted {
-                continue;
-            }
-            let joined = single_row_context(&table, rows[i].clone());
-            let matches = if let Some(selection) = &stmt.selection {
-                eval_predicate(
-                    selection,
-                    &joined,
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?
-            } else {
-                true
-            };
+        let query_executor = QueryExecutor {
+            catalog: self.catalog,
+            storage: self.storage,
+            clock: self.clock,
+        };
 
-            if matches {
-                enforce_foreign_keys_on_delete(&table, self.catalog, self.storage, &rows[i])?;
-                apply_assignments(
-                    &table,
-                    &mut rows[i],
-                    &stmt.assignments,
-                    &joined,
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?;
-                validate_row_against_table(&table, &rows[i].values)?;
-                enforce_foreign_keys_on_insert(&table, self.catalog, self.storage, &rows[i])?;
-                enforce_checks_on_row(
-                    &table,
-                    &rows[i],
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?;
-                updated_indices.push(i);
-            }
-        }
+        let joined_rows = query_executor.execute_to_joined_rows(query_stmt, ctx)?;
 
-        for &idx in &updated_indices {
-            enforce_unique_on_update(&table, self.storage, table_id, &rows[idx], idx)?;
-            self.storage.update_row(table_id, idx, rows[idx].clone())?;
-        }
+        let mut updated_indices = HashSet::new();
+        let mut inserted_rows_for_output = Vec::new();
+        let mut deleted_rows_for_output = Vec::new();
 
-        Ok(())
-    }
+        for joined_row in joined_rows {
+            let target_ctx = joined_row
+                .iter()
+                .find(|ct| ct.table.id == table_id)
+                .ok_or_else(|| DbError::Execution("target table not found in join context".into()))?;
 
-    fn execute_update_with_from(
-        &mut self,
-        table: &TableDef,
-        table_id: u32,
-        rows: &mut Vec<StoredRow>,
-        stmt: &UpdateStmt,
-        from_clause: &FromClause,
-        ctx: &mut ExecutionContext,
-    ) -> Result<(), DbError> {
-        let mut updated_indices = Vec::new();
+            if let (Some(stored_row), Some(idx)) = (&target_ctx.row, target_ctx.storage_index) {
+                if !updated_indices.contains(&idx) {
+                    let mut new_row = stored_row.clone();
+                    enforce_foreign_keys_on_delete(&table, self.catalog, self.storage, stored_row)?;
+                    apply_assignments(
+                        &table,
+                        &mut new_row,
+                        &stmt.assignments,
+                        &joined_row,
+                        ctx,
+                        self.catalog,
+                        self.storage,
+                        self.clock,
+                    )?;
+                    validate_row_against_table(&table, &new_row.values)?;
+                    enforce_foreign_keys_on_insert(&table, self.catalog, self.storage, &new_row)?;
+                    enforce_checks_on_row(
+                        &table,
+                        &new_row,
+                        ctx,
+                        self.catalog,
+                        self.storage,
+                        self.clock,
+                    )?;
+                    enforce_unique_on_update(&table, self.storage, table_id, &new_row, idx)?;
 
-        for i in 0..rows.len() {
-            if rows[i].deleted {
-                continue;
-            }
+                    self.storage.update_row(table_id, idx, new_row.clone())?;
+                    updated_indices.insert(idx);
 
-            let mut combined_ctx: super::super::model::JoinedRow =
-                single_row_context(table, rows[i].clone());
-
-            let mut all_match = true;
-            for from_table_ref in &from_clause.tables {
-                let resolved_name = ctx
-                    .resolve_table_name(&from_table_ref.name.name)
-                    .unwrap_or_else(|| from_table_ref.name.name.clone());
-                let from_schema = from_table_ref.name.schema_or_dbo();
-                let from_table = self
-                    .catalog
-                    .find_table(from_schema, &resolved_name)
-                    .ok_or_else(|| {
-                        DbError::Semantic(format!(
-                            "table '{}.{}' not found",
-                            from_schema, resolved_name
-                        ))
-                    })?
-                    .clone();
-                let from_rows = self.storage.get_rows(from_table.id)?;
-                let non_deleted: Vec<_> = from_rows.iter().filter(|r| !r.deleted).collect();
-                if non_deleted.is_empty() {
-                    all_match = false;
-                    break;
-                }
-                let alias = from_table_ref
-                    .alias
-                    .clone()
-                    .unwrap_or_else(|| resolved_name.clone());
-                combined_ctx.push(super::super::model::ContextTable {
-                    table: from_table.clone(),
-                    alias: alias.clone(),
-                    row: Some(non_deleted[0].clone()),
-                });
-            }
-
-            if !all_match {
-                continue;
-            }
-
-            for join_clause in &from_clause.joins {
-                let resolved_name = ctx
-                    .resolve_table_name(&join_clause.table.name.name)
-                    .unwrap_or_else(|| join_clause.table.name.name.clone());
-                let join_schema = join_clause.table.name.schema_or_dbo();
-                let join_table = self
-                    .catalog
-                    .find_table(join_schema, &resolved_name)
-                    .ok_or_else(|| {
-                        DbError::Semantic(format!(
-                            "table '{}.{}' not found",
-                            join_schema, resolved_name
-                        ))
-                    })?
-                    .clone();
-                let join_rows = self.storage.get_rows(join_table.id)?;
-
-                let mut found_match = false;
-                let alias = join_clause
-                    .table
-                    .alias
-                    .clone()
-                    .unwrap_or_else(|| resolved_name.clone());
-                for join_row in join_rows.iter().filter(|r| !r.deleted) {
-                    let mut test_ctx = combined_ctx.clone();
-                    test_ctx.push(super::super::model::ContextTable {
-                        table: join_table.clone(),
-                        alias: alias.clone(),
-                        row: Some(join_row.clone()),
-                    });
-                    if let Some(ref on_expr) = join_clause.on {
-                        if eval_predicate(
-                            on_expr,
-                            &test_ctx,
-                            ctx,
-                            self.catalog,
-                            self.storage,
-                            self.clock,
-                        )? {
-                            combined_ctx = test_ctx;
-                            found_match = true;
-                            break;
-                        }
+                    if stmt.output.is_some() {
+                        inserted_rows_for_output.push(new_row);
+                        deleted_rows_for_output.push(stored_row.clone());
                     }
                 }
-                match join_clause.join_type {
-                    JoinType::Inner => {
-                        if !found_match {
-                            all_match = false;
-                            break;
-                        }
-                    }
-                    JoinType::Left => {}
-                    _ => {}
-                }
-            }
-
-            if !all_match {
-                continue;
-            }
-
-            let matches = if let Some(selection) = &stmt.selection {
-                eval_predicate(
-                    selection,
-                    &combined_ctx,
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?
-            } else {
-                true
-            };
-
-            if matches {
-                enforce_foreign_keys_on_delete(table, self.catalog, self.storage, &rows[i])?;
-                apply_assignments(
-                    table,
-                    &mut rows[i],
-                    &stmt.assignments,
-                    &combined_ctx,
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?;
-                validate_row_against_table(table, &rows[i].values)?;
-                enforce_foreign_keys_on_insert(table, self.catalog, self.storage, &rows[i])?;
-                enforce_checks_on_row(
-                    table,
-                    &rows[i],
-                    ctx,
-                    self.catalog,
-                    self.storage,
-                    self.clock,
-                )?;
-                updated_indices.push(i);
             }
         }
 
-        for &idx in &updated_indices {
-            enforce_unique_on_update(table, self.storage, table_id, &rows[idx], idx)?;
-            self.storage.update_row(table_id, idx, rows[idx].clone())?;
+        if let Some(output) = stmt.output {
+            let inserted: Vec<&crate::storage::StoredRow> = inserted_rows_for_output.iter().collect();
+            let deleted: Vec<&crate::storage::StoredRow> = deleted_rows_for_output.iter().collect();
+            return build_output_result(&output, &table, &inserted, &deleted);
         }
 
-        Ok(())
+        Ok(None)
     }
 }

--- a/crates/tsql_core/src/executor/query.rs
+++ b/crates/tsql_core/src/executor/query.rs
@@ -111,6 +111,71 @@ impl<'a> QueryExecutor<'a> {
             source_rows = filtered;
         }
 
+        self.execute_physical_plan_to_result(plan, source_rows, ctx)
+    }
+
+    pub fn execute_to_joined_rows(
+        &self,
+        stmt: SelectStmt,
+        ctx: &mut ExecutionContext,
+    ) -> Result<Vec<JoinedRow>, DbError> {
+        let logical = build_logical_plan(&stmt)?;
+        let plan = build_physical_plan(
+            &stmt,
+            &logical,
+            self.catalog,
+            ctx,
+            |tref, cat, c| self.bind_table(tref, cat, c),
+        )?;
+
+        let mut source_rows =
+            execute_scan(&plan.base, ctx, self.catalog, self.storage, self.clock)?;
+
+        for join_plan in &plan.joins {
+            let right_rows =
+                execute_scan(&join_plan.right, ctx, self.catalog, self.storage, self.clock)?;
+            source_rows = apply_join(
+                source_rows,
+                right_rows,
+                join_plan.right.bound.clone(),
+                &join_plan.join,
+                ctx,
+                self.catalog,
+                self.storage,
+                self.clock,
+            )?;
+        }
+
+        for apply_clause in &plan.applies {
+            source_rows = self.execute_apply(source_rows, apply_clause, ctx)?;
+        }
+
+        if let Some(where_clause) = &plan.residual_filter {
+            let mut filtered = Vec::new();
+            for row in source_rows {
+                if eval_predicate(
+                    where_clause,
+                    &row,
+                    ctx,
+                    self.catalog,
+                    self.storage,
+                    self.clock,
+                )? {
+                    filtered.push(row);
+                }
+            }
+            source_rows = filtered;
+        }
+
+        Ok(source_rows)
+    }
+
+    fn execute_physical_plan_to_result(
+        &self,
+        plan: PhysicalPlan,
+        source_rows: Vec<JoinedRow>,
+        ctx: &mut ExecutionContext,
+    ) -> Result<super::result::QueryResult, DbError> {
         let has_aggregate = plan
             .projection
             .iter()
@@ -425,6 +490,7 @@ impl<'a> QueryExecutor<'a> {
                         table: null_table,
                         alias: apply.alias.clone(),
                         row: None,
+                        storage_index: None,
                     });
                     result_rows.push(combined);
                 }
@@ -456,7 +522,7 @@ impl<'a> QueryExecutor<'a> {
                     check_constraints: vec![], foreign_keys: vec![],
 
                 };
-                for sub_row_values in &sub_result.rows {
+                for (idx, sub_row_values) in sub_result.rows.iter().enumerate() {
                     let mut combined = left_row.clone();
                     combined.push(ContextTable {
                         table: apply_table.clone(),
@@ -465,6 +531,7 @@ impl<'a> QueryExecutor<'a> {
                             values: sub_row_values.clone(),
                             deleted: false,
                         }),
+                        storage_index: Some(idx),
                     });
                     result_rows.push(combined);
                 }

--- a/crates/tsql_core/src/executor/query_planner.rs
+++ b/crates/tsql_core/src/executor/query_planner.rs
@@ -235,11 +235,13 @@ fn bind_table_rows(
     if let Some(rows) = &bound.virtual_rows {
         return Ok(rows
             .iter()
-            .map(|row| {
+            .enumerate()
+            .map(|(i, row)| {
                 vec![super::model::ContextTable {
                     table: bound.table.clone(),
                     alias: bound.alias.clone(),
                     row: Some(row.clone()),
+                    storage_index: Some(i),
                 }]
             })
             .collect());
@@ -249,12 +251,14 @@ fn bind_table_rows(
 
     Ok(stored_rows
         .iter()
-        .filter(|r| !r.deleted)
-        .map(|row| {
+        .enumerate()
+        .filter(|(_, r)| !r.deleted)
+        .map(|(i, row)| {
             vec![super::model::ContextTable {
                 table: bound.table.clone(),
                 alias: bound.alias.clone(),
                 row: Some(row.clone()),
+                storage_index: Some(i),
             }]
         })
         .collect())

--- a/crates/tsql_core/src/executor/script/dml.rs
+++ b/crates/tsql_core/src/executor/script/dml.rs
@@ -94,6 +94,7 @@ impl<'a> ScriptExecutor<'a> {
                     table: target_table.clone(),
                     alias: target_alias.clone(),
                     row: Some(target_rows[i].clone()),
+                    storage_index: Some(i),
                 }];
 
                 // Add source row context
@@ -141,6 +142,7 @@ impl<'a> ScriptExecutor<'a> {
                         values: source_row.clone(),
                         deleted: false,
                     }),
+                    storage_index: Some(s_idx),
                 });
 
                 let on_matches = super::super::evaluator::eval_predicate(
@@ -286,6 +288,7 @@ impl<'a> ScriptExecutor<'a> {
                     values: source_row.clone(),
                     deleted: false,
                 }),
+                storage_index: Some(s_idx),
             }];
 
             for when_clause in &stmt.when_clauses {

--- a/crates/tsql_core/src/executor/script/mod.rs
+++ b/crates/tsql_core/src/executor/script/mod.rs
@@ -117,50 +117,12 @@ impl<'a> ScriptExecutor<'a> {
                 .drop_view(stmt)?;
                 Ok(None)
             }
-            Statement::Insert(stmt) => {
-                let has_output = stmt.output.is_some();
-                if !has_output {
-                    MutationExecutor {
-                        catalog: self.catalog,
-                        storage: self.storage,
-                        clock: self.clock,
-                    }
-                    .execute_insert_with_context(stmt, ctx)?;
-                    return Ok(None);
-                }
-
-                let schema = stmt.table.schema_or_dbo().to_string();
-                let table_name = stmt.table.name.clone();
-                let table = self
-                    .catalog
-                    .find_table(&schema, &table_name)
-                    .ok_or_else(|| {
-                        DbError::Semantic(format!("table '{}.{}' not found", schema, table_name))
-                    })?
-                    .clone();
-
-                let before_total = self.storage.get_rows(table.id)?.len();
-
-                MutationExecutor {
-                    catalog: self.catalog,
-                    storage: self.storage,
-                    clock: self.clock,
-                }
-                .execute_insert_with_context(stmt.clone(), ctx)?;
-
-                let after_rows = self.storage.get_rows(table.id)?;
-                let inserted: Vec<_> = after_rows[before_total..]
-                    .iter()
-                    .filter(|r| !r.deleted)
-                    .collect();
-
-                super::mutation::build_output_result(
-                    &stmt.output.unwrap(),
-                    &table,
-                    &inserted,
-                    &[],
-                )
+            Statement::Insert(stmt) => MutationExecutor {
+                catalog: self.catalog,
+                storage: self.storage,
+                clock: self.clock,
             }
+            .execute_insert_with_context(stmt, ctx),
             Statement::Select(stmt) => QueryExecutor {
                 catalog: self.catalog as &dyn Catalog,
                 storage: self.storage as &dyn Storage,
@@ -168,100 +130,18 @@ impl<'a> ScriptExecutor<'a> {
             }
             .execute_select(stmt, ctx)
             .map(Some),
-            Statement::Update(stmt) => {
-                let has_output = stmt.output.is_some();
-                if !has_output {
-                    MutationExecutor {
-                        catalog: self.catalog,
-                        storage: self.storage,
-                        clock: self.clock,
-                    }
-                    .execute_update_with_context(stmt, ctx)?;
-                    return Ok(None);
-                }
-
-                let schema = stmt.table.schema_or_dbo().to_string();
-                let table_name = stmt.table.name.clone();
-                let table = self
-                    .catalog
-                    .find_table(&schema, &table_name)
-                    .ok_or_else(|| {
-                        DbError::Semantic(format!("table '{}.{}' not found", schema, table_name))
-                    })?
-                    .clone();
-
-                let before_rows = self.storage.get_rows(table.id)?;
-
-                MutationExecutor {
-                    catalog: self.catalog,
-                    storage: self.storage,
-                    clock: self.clock,
-                }
-                .execute_update_with_context(stmt.clone(), ctx)?;
-
-                let after_rows = self.storage.get_rows(table.id)?;
-                let mut inserted = Vec::new();
-                let mut deleted = Vec::new();
-                for (before, after) in before_rows.iter().zip(after_rows.iter()) {
-                    if !before.deleted && !after.deleted && before.values != after.values {
-                        inserted.push(after);
-                        deleted.push(before);
-                    }
-                }
-
-                super::mutation::build_output_result(
-                    &stmt.output.unwrap(),
-                    &table,
-                    &inserted,
-                    &deleted,
-                )
+            Statement::Update(stmt) => MutationExecutor {
+                catalog: self.catalog,
+                storage: self.storage,
+                clock: self.clock,
             }
-            Statement::Delete(stmt) => {
-                let has_output = stmt.output.is_some();
-                if !has_output {
-                    MutationExecutor {
-                        catalog: self.catalog,
-                        storage: self.storage,
-                        clock: self.clock,
-                    }
-                    .execute_delete_with_context(stmt, ctx)?;
-                    return Ok(None);
-                }
-
-                let schema = stmt.table.schema_or_dbo().to_string();
-                let table_name = stmt.table.name.clone();
-                let table = self
-                    .catalog
-                    .find_table(&schema, &table_name)
-                    .ok_or_else(|| {
-                        DbError::Semantic(format!("table '{}.{}' not found", schema, table_name))
-                    })?
-                    .clone();
-
-                let before_rows = self.storage.get_rows(table.id)?;
-
-                MutationExecutor {
-                    catalog: self.catalog,
-                    storage: self.storage,
-                    clock: self.clock,
-                }
-                .execute_delete_with_context(stmt.clone(), ctx)?;
-
-                let after_rows = self.storage.get_rows(table.id)?;
-                let deleted: Vec<_> = before_rows
-                    .iter()
-                    .zip(after_rows.iter())
-                    .filter(|(before, after)| !before.deleted && after.deleted)
-                    .map(|(before, _)| before)
-                    .collect();
-
-                super::mutation::build_output_result(
-                    &stmt.output.unwrap(),
-                    &table,
-                    &[],
-                    &deleted,
-                )
+            .execute_update_with_context(stmt, ctx),
+            Statement::Delete(stmt) => MutationExecutor {
+                catalog: self.catalog,
+                storage: self.storage,
+                clock: self.clock,
             }
+            .execute_delete_with_context(stmt, ctx),
             Statement::TruncateTable(mut stmt) => {
                 if let Some(mapped) = ctx.resolve_table_name(&stmt.name.name) {
                     stmt.name.name = mapped;


### PR DESCRIPTION
Refactor DML (UPDATE, DELETE, INSERT) to use `QueryExecutor` for row identification, ensuring robust support for joins and filters while streamlining `OUTPUT` clause handling.

---
*PR created automatically by Jules for task [5261246334309081942](https://jules.google.com/task/5261246334309081942) started by @celsowm*