### PR TITLE
Phase 3: Deadlock Detection

### DIFF
--- a/crates/tsql_core/src/error.rs
+++ b/crates/tsql_core/src/error.rs
@@ -21,6 +21,9 @@ pub enum DbError {
 
     #[error("storage error: {0}")]
     Storage(String),
+
+    #[error("deadlock: {0}")]
+    Deadlock(String),
 }
 
 impl DbError {
@@ -28,7 +31,7 @@ impl DbError {
         match self {
             DbError::Parse(_) => ErrorClass::Parse,
             DbError::Semantic(_) => ErrorClass::Semantic,
-            DbError::Execution(_) => ErrorClass::Execution,
+            DbError::Execution(_) | DbError::Deadlock(_) => ErrorClass::Execution,
             DbError::Storage(_) => ErrorClass::Storage,
         }
     }
@@ -39,6 +42,7 @@ impl DbError {
             DbError::Semantic(_) => "TSQL_SEMANTIC_ERROR",
             DbError::Execution(_) => "TSQL_EXECUTION_ERROR",
             DbError::Storage(_) => "TSQL_STORAGE_ERROR",
+            DbError::Deadlock(_) => "TSQL_DEADLOCK_ERROR",
         }
     }
 }

--- a/crates/tsql_core/src/executor/database/engine.rs
+++ b/crates/tsql_core/src/executor/database/engine.rs
@@ -62,7 +62,7 @@ impl EngineInner<CatalogImpl, InMemoryStorage> {
         })
     }
 
-    pub fn reset(&mut self) {
+    pub fn reset(&self) {
         self.db.reset();
     }
 
@@ -81,35 +81,43 @@ impl EngineInner<CatalogImpl, InMemoryStorage> {
         self.db.clone()
     }
 
-    pub fn execute(&mut self, stmt: Statement) -> Result<Option<QueryResult>, DbError> {
+    pub fn execute(&self, stmt: Statement) -> Result<Option<QueryResult>, DbError> {
         StatementExecutor::execute_session(&self.db, self.default_session, stmt)
     }
 
-    pub fn exec(&mut self, sql: &str) -> Result<(), DbError> {
+    pub fn exec(&self, sql: &str) -> Result<(), DbError> {
         let quoted_ident = self.session_options().quoted_identifier;
         let stmt = parse_sql_with_quoted_ident(sql, quoted_ident)?;
-        let res = self.execute(stmt)?;
+        let res = StatementExecutor::execute_session(&self.db, self.default_session, stmt)?;
         if res.is_some() {
             return Err(DbError::Execution("exec() received a query statement; use query()".into()));
         }
         Ok(())
     }
 
-    pub fn query(&mut self, sql: &str) -> Result<QueryResult, DbError> {
+    pub fn query(&self, sql: &str) -> Result<QueryResult, DbError> {
         let quoted_ident = self.session_options().quoted_identifier;
         let stmt = parse_sql_with_quoted_ident(sql, quoted_ident)?;
-        let res = self.execute(stmt)?;
+        let res = StatementExecutor::execute_session(&self.db, self.default_session, stmt)?;
         res.ok_or_else(|| DbError::Execution("query() expected a result set".into()))
     }
 
     pub fn execute_batch(
-        &mut self,
+        &self,
         stmts: Vec<Statement>,
     ) -> Result<Option<QueryResult>, DbError> {
         StatementExecutor::execute_session_batch(&self.db, self.default_session, stmts)
     }
 
-    pub fn set_journal(&mut self, journal: Box<dyn Journal>) {
+    pub fn execute_session_batch_sql(
+        &self,
+        session_id: SessionId,
+        sql: &str,
+    ) -> Result<Option<QueryResult>, DbError> {
+        StatementExecutor::execute_session_batch_sql(&self.db, session_id, sql)
+    }
+
+    pub fn set_journal(&self, journal: Box<dyn Journal>) {
         let _ = self.db.set_session_journal(self.default_session, journal);
     }
 
@@ -124,7 +132,7 @@ impl EngineInner<CatalogImpl, InMemoryStorage> {
         CheckpointManager::export_checkpoint(&self.db)
     }
 
-    pub fn import_checkpoint(&mut self, payload: &str) -> Result<(), DbError> {
+    pub fn import_checkpoint(&self, payload: &str) -> Result<(), DbError> {
         CheckpointManager::import_checkpoint(&self.db, payload)
     }
 

--- a/crates/tsql_core/src/executor/database/execution.rs
+++ b/crates/tsql_core/src/executor/database/execution.rs
@@ -130,6 +130,19 @@ where
                 stmt,
             ) {
                 Ok(r) => out = Ok(r),
+                Err(DbError::Deadlock(e)) => {
+                    transaction_exec::force_xact_abort(
+                        state,
+                        session_id,
+                        &mut session.tx_manager,
+                        session.journal.as_mut(),
+                        &mut session.workspace,
+                        &mut ctx,
+                        &mut session.options,
+                    );
+                    out = Err(DbError::Deadlock(e));
+                    break;
+                }
                 Err(e) => {
                     out = Err(e);
                     break;
@@ -162,6 +175,19 @@ where
                         }
                         StmtOutcome::Ok(v) => out = Ok(v),
                     }
+                }
+                Err(DbError::Deadlock(e)) => {
+                    transaction_exec::force_xact_abort(
+                        state,
+                        session_id,
+                        &mut session.tx_manager,
+                        session.journal.as_mut(),
+                        &mut session.workspace,
+                        &mut ctx,
+                        &mut session.options,
+                    );
+                    out = Err(DbError::Deadlock(e));
+                    break;
                 }
                 Err(e) => {
                     out = Err(e);
@@ -238,6 +264,25 @@ where
                 stmt,
             ) {
                 Ok(r) => results.push(r),
+                Err(DbError::Deadlock(e)) => {
+                    transaction_exec::force_xact_abort(
+                        state,
+                        session_id,
+                        &mut session.tx_manager,
+                        session.journal.as_mut(),
+                        &mut session.workspace,
+                        &mut ctx,
+                        &mut session.options,
+                    );
+                    let mut storage_guard = state.storage.write();
+                    let (cat, stor) = storage_guard.get_mut_refs();
+                    let _ = cleanup_scope_table_vars(
+                        cat,
+                        stor,
+                        &mut ctx,
+                    );
+                    return Err(DbError::Deadlock(e));
+                }
                 Err(e) => {
                     let mut storage_guard = state.storage.write();
                     let (cat, stor) = storage_guard.get_mut_refs();
@@ -280,6 +325,25 @@ where
                         }
                         StmtOutcome::Ok(v) => results.push(v),
                     }
+                }
+                Err(DbError::Deadlock(e)) => {
+                    transaction_exec::force_xact_abort(
+                        state,
+                        session_id,
+                        &mut session.tx_manager,
+                        session.journal.as_mut(),
+                        &mut session.workspace,
+                        &mut ctx,
+                        &mut session.options,
+                    );
+                    let mut storage_guard = state.storage.write();
+                    let (cat, stor) = storage_guard.get_mut_refs();
+                    let _ = cleanup_scope_table_vars(
+                        cat,
+                        stor,
+                        &mut ctx,
+                    );
+                    return Err(DbError::Deadlock(e));
                 }
                 Err(e) => {
                     let mut storage_guard = state.storage.write();
@@ -374,6 +438,18 @@ where
     ) {
         // Swallow RETURN at the top level; BREAK/CONTINUE outside loops are errors
         Ok(outcome) => outcome.into_result_swallow_return(),
+        Err(DbError::Deadlock(e)) => {
+            transaction_exec::force_xact_abort(
+                state,
+                session_id,
+                &mut session.tx_manager,
+                session.journal.as_mut(),
+                &mut session.workspace,
+                &mut ctx,
+                &mut session.options,
+            );
+            Err(DbError::Deadlock(e))
+        }
         Err(e) => Err(e),
     }
 }

--- a/crates/tsql_core/src/executor/deadlock.rs
+++ b/crates/tsql_core/src/executor/deadlock.rs
@@ -1,0 +1,78 @@
+use std::collections::{HashMap, HashSet};
+use super::locks::SessionId;
+
+#[derive(Debug, Default)]
+pub struct WaitForGraph {
+    /// waiter_session_id -> set of session_ids it's waiting on
+    edges: HashMap<SessionId, HashSet<SessionId>>,
+}
+
+impl WaitForGraph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_edge(&mut self, waiter: SessionId, holder: SessionId) {
+        if waiter == holder {
+            return;
+        }
+        self.edges.entry(waiter).or_default().insert(holder);
+    }
+
+    pub fn remove_edge(&mut self, waiter: SessionId, holder: SessionId) {
+        if let Some(holders) = self.edges.get_mut(&waiter) {
+            holders.remove(&holder);
+            if holders.is_empty() {
+                self.edges.remove(&waiter);
+            }
+        }
+    }
+
+    pub fn remove_waiter(&mut self, waiter: SessionId) {
+        self.edges.remove(&waiter);
+    }
+
+    pub fn detect_cycle(&self, start_session: SessionId) -> Option<Vec<SessionId>> {
+        let mut visited = HashSet::new();
+        let mut in_stack = HashSet::new();
+        let mut path = Vec::new();
+
+        if self.has_cycle(start_session, &mut visited, &mut in_stack, &mut path) {
+            return Some(path);
+        }
+        None
+    }
+
+    fn has_cycle(
+        &self,
+        current: SessionId,
+        visited: &mut HashSet<SessionId>,
+        in_stack: &mut HashSet<SessionId>,
+        path: &mut Vec<SessionId>,
+    ) -> bool {
+        visited.insert(current);
+        in_stack.insert(current);
+        path.push(current);
+
+        if let Some(holders) = self.edges.get(&current) {
+            for &holder in holders {
+                if !visited.contains(&holder) {
+                    if self.has_cycle(holder, visited, in_stack, path) {
+                        return true;
+                    }
+                } else if in_stack.contains(&holder) {
+                    // Cycle detected!
+                    // Trim path to only include the cycle
+                    if let Some(pos) = path.iter().position(|&x| x == holder) {
+                        *path = path[pos..].to_vec();
+                    }
+                    return true;
+                }
+            }
+        }
+
+        in_stack.remove(&current);
+        path.pop();
+        false
+    }
+}

--- a/crates/tsql_core/src/executor/locks.rs
+++ b/crates/tsql_core/src/executor/locks.rs
@@ -62,6 +62,7 @@ impl<C: Clone, S: Clone> Clone for TxWorkspace<C, S> {
 pub struct LockTable {
     locks: HashMap<String, TableLockState>,
     pub condvar: std::sync::Arc<parking_lot::Condvar>,
+    pub wait_for_graph: super::deadlock::WaitForGraph,
 }
 
 impl Default for LockTable {
@@ -69,6 +70,7 @@ impl Default for LockTable {
         Self {
             locks: HashMap::new(),
             condvar: std::sync::Arc::new(parking_lot::Condvar::new()),
+            wait_for_graph: super::deadlock::WaitForGraph::new(),
         }
     }
 }
@@ -140,17 +142,22 @@ impl LockTable {
         loop {
             let mut all_acquired = true;
             let mut conflict_info = None;
+            let mut holders = std::collections::HashSet::new();
 
             // Try to acquire all locks
             for (table, mode) in &tables_to_lock {
                 if !guard.can_acquire_lock(session_id, table, *mode) {
                     all_acquired = false;
                     conflict_info = Some((table.clone(), *mode));
+                    for h in guard.get_blocking_sessions(session_id, table, *mode) {
+                        holders.insert(h);
+                    }
                     break;
                 }
             }
 
             if all_acquired {
+                guard.wait_for_graph.remove_waiter(session_id);
                 for (table, mode) in tables_to_lock {
                     guard.perform_acquire_lock(session_id, workspace_slot, &table, mode, depth);
                 }
@@ -165,8 +172,23 @@ impl LockTable {
                 )));
             }
 
+            // Deadlock detection before waiting
+            guard.wait_for_graph.remove_waiter(session_id);
+            for &holder in &holders {
+                guard.wait_for_graph.add_edge(session_id, holder);
+            }
+
+            if let Some(cycle) = guard.wait_for_graph.detect_cycle(session_id) {
+                guard.wait_for_graph.remove_waiter(session_id);
+                return Err(DbError::Deadlock(format!(
+                    "Transaction was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Cycle: {:?}",
+                    cycle
+                )));
+            }
+
             let elapsed = start.elapsed();
             if timeout_ms > 0 && elapsed.as_millis() >= timeout_ms as u128 {
+                guard.wait_for_graph.remove_waiter(session_id);
                 let (table, mode) = conflict_info.unwrap();
                 return Err(DbError::Execution(format!(
                     "lock timeout ({}ms): {:?} lock on '{}' is blocked",
@@ -181,6 +203,7 @@ impl LockTable {
                 let remaining = std::time::Duration::from_millis(timeout_ms as u64)
                     .saturating_sub(elapsed);
                 if condvar.wait_for(&mut guard, remaining).timed_out() {
+                    guard.wait_for_graph.remove_waiter(session_id);
                     let (table, mode) = conflict_info.unwrap();
                     return Err(DbError::Execution(format!(
                         "lock timeout ({}ms): {:?} lock on '{}' is blocked",
@@ -189,6 +212,37 @@ impl LockTable {
                 }
             }
         }
+    }
+
+    pub fn get_blocking_sessions(&self, session_id: SessionId, table: &str, mode: LockMode) -> Vec<SessionId> {
+        let normalized = table.to_uppercase();
+        let Some(lock_state) = self.locks.get(&normalized) else {
+            return Vec::new();
+        };
+
+        let mut blockers = Vec::new();
+        match mode {
+            LockMode::Read => {
+                if let Some((writer, _)) = lock_state.writer {
+                    if writer != session_id {
+                        blockers.push(writer);
+                    }
+                }
+            }
+            LockMode::Write => {
+                if let Some((writer, _)) = lock_state.writer {
+                    if writer != session_id {
+                        blockers.push(writer);
+                    }
+                }
+                for (reader, count) in &lock_state.readers {
+                    if *reader != session_id && *count > 0 {
+                        blockers.push(*reader);
+                    }
+                }
+            }
+        }
+        blockers
     }
 
     fn can_acquire_lock(&self, session_id: SessionId, table: &str, mode: LockMode) -> bool {
@@ -285,6 +339,7 @@ impl LockTable {
         for table in tables {
             self.release_all_for_table(session_id, &table);
         }
+        self.wait_for_graph.remove_waiter(session_id);
         self.condvar.notify_all();
     }
 

--- a/crates/tsql_core/src/executor/mod.rs
+++ b/crates/tsql_core/src/executor/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod aggregates;
 pub mod clock;
 pub mod conflict;
+pub(crate) mod deadlock;
 pub(crate) mod dirty_buffer;
 pub mod context;
 pub(crate) mod cte;

--- a/crates/tsql_core/tests/concurrency_deadlock.rs
+++ b/crates/tsql_core/tests/concurrency_deadlock.rs
@@ -1,0 +1,111 @@
+use tsql_core::executor::engine::Engine;
+use tsql_core::error::DbError;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn test_deadlock_2_sessions() {
+    let engine = Arc::new(Engine::new());
+
+    // Setup tables
+    engine.exec("CREATE TABLE A (id INT)").unwrap();
+    engine.exec("CREATE TABLE B (id INT)").unwrap();
+
+    let s1 = engine.create_session();
+    let s2 = engine.create_session();
+
+    // Set lock timeout so they wait and can be deadlocked
+    engine.execute_session_batch_sql(s1, "SET LOCK_TIMEOUT 5000;").unwrap();
+    engine.execute_session_batch_sql(s2, "SET LOCK_TIMEOUT 5000;").unwrap();
+
+    // Session 1: Begin Tran, Lock A
+    engine.execute_session_batch_sql(s1, "BEGIN TRANSACTION; INSERT INTO A VALUES (1);").unwrap();
+
+    // Session 2: Begin Tran, Lock B
+    engine.execute_session_batch_sql(s2, "BEGIN TRANSACTION; INSERT INTO B VALUES (1);").unwrap();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    // Session 1 tries to lock B (will block)
+    let engine_s1 = engine.clone();
+    thread::spawn(move || {
+        let res = engine_s1.execute_session_batch_sql(s1, "INSERT INTO B VALUES (2);");
+        tx.send(res).unwrap();
+    });
+
+    // Wait a bit to ensure S1 is waiting
+    thread::sleep(Duration::from_millis(100));
+
+    // Session 2 tries to lock A (DEADLOCK!)
+    let res_s2 = engine.execute_session_batch_sql(s2, "INSERT INTO A VALUES (2);");
+
+    let res_s1 = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+
+    // One of them must be a deadlock victim
+    let s1_deadlock = matches!(res_s1, Err(DbError::Deadlock(_)));
+    let s2_deadlock = matches!(res_s2, Err(DbError::Deadlock(_)));
+
+    assert!(s1_deadlock || s2_deadlock, "One session should have deadlocked. S1: {:?}, S2: {:?}", res_s1, res_s2);
+
+    // The victim's transaction should be rolled back.
+    if s1_deadlock {
+        // S1 was victim, B should be unlocked, so S2 should have succeeded (eventually)
+        assert!(res_s2.is_ok());
+    } else {
+        // S2 was victim, A should be unlocked, so S1 should have succeeded (eventually)
+        assert!(res_s1.is_ok());
+    }
+}
+
+#[test]
+fn test_deadlock_3_sessions() {
+    let engine = Arc::new(Engine::new());
+
+    // Setup tables
+    engine.exec("CREATE TABLE A (id INT)").unwrap();
+    engine.exec("CREATE TABLE B (id INT)").unwrap();
+    engine.exec("CREATE TABLE C (id INT)").unwrap();
+
+    let s1 = engine.create_session();
+    let s2 = engine.create_session();
+    let s3 = engine.create_session();
+
+    // Set lock timeout
+    engine.execute_session_batch_sql(s1, "SET LOCK_TIMEOUT 5000;").unwrap();
+    engine.execute_session_batch_sql(s2, "SET LOCK_TIMEOUT 5000;").unwrap();
+    engine.execute_session_batch_sql(s3, "SET LOCK_TIMEOUT 5000;").unwrap();
+
+    // S1 locks A
+    engine.execute_session_batch_sql(s1, "BEGIN TRANSACTION; INSERT INTO A VALUES (1);").unwrap();
+    // S2 locks B
+    engine.execute_session_batch_sql(s2, "BEGIN TRANSACTION; INSERT INTO B VALUES (1);").unwrap();
+    // S3 locks C
+    engine.execute_session_batch_sql(s3, "BEGIN TRANSACTION; INSERT INTO C VALUES (1);").unwrap();
+
+    let (tx1, rx1) = std::sync::mpsc::channel();
+    let (tx2, rx2) = std::sync::mpsc::channel();
+
+    // S1 waits for B (held by S2)
+    let e1 = engine.clone();
+    thread::spawn(move || {
+        tx1.send(e1.execute_session_batch_sql(s1, "INSERT INTO B VALUES (2);")).unwrap();
+    });
+    thread::sleep(Duration::from_millis(100));
+
+    // S2 waits for C (held by S3)
+    let e2 = engine.clone();
+    thread::spawn(move || {
+        tx2.send(e2.execute_session_batch_sql(s2, "INSERT INTO C VALUES (2);")).unwrap();
+    });
+    thread::sleep(Duration::from_millis(100));
+
+    // S3 waits for A (held by S1) -> CYCLE: S1->S2->S3->S1
+    let res_s3 = engine.execute_session_batch_sql(s3, "INSERT INTO A VALUES (2);");
+
+    let res_s1 = rx1.recv_timeout(Duration::from_secs(5)).expect("S1 failed to report");
+    let res_s2 = rx2.recv_timeout(Duration::from_secs(5)).expect("S2 failed to report");
+
+    let deadlocks = [res_s1, res_s2, res_s3].iter().filter(|r| matches!(r, Err(DbError::Deadlock(_)))).count();
+    assert!(deadlocks >= 1, "At least one session should have deadlocked");
+}


### PR DESCRIPTION
This change implements Phase 3 of the concurrency plan: Deadlock Detection.

Key features:
1. **Wait-For Graph (WFG)**: A new module `crates/tsql_core/src/executor/deadlock.rs` manages the dependency graph between sessions. It uses a Depth-First Search (DFS) with an optimized `HashSet`-based stack check to detect cycles.
2. **LockTable Integration**: When a session is blocked in `acquire_statement_locks`, it identifies all sessions holding the conflicting locks and adds edges to the WFG. Cycle detection is performed *before* the session parks on the condition variable.
3. **Deadlock Victim Handling**: If a cycle is detected, the current session is chosen as the deadlock victim. It returns `DbError::Deadlock`, which is caught by the batch/single statement executors to trigger an immediate `force_xact_abort` (rollback), matching T-SQL semantics.
4. **Clean Edge Management**: Edges are removed from the WFG as soon as a session stops waiting (lock acquired, timeout, or deadlock), preventing stale dependencies and false positives.
5. **Engine Refactoring**: `EngineInner` was updated to take `&self` for its execution methods, reflecting that it is now backed by thread-safe shared state with internal locking.
6. **Tests**: New integration tests in `crates/tsql_core/tests/concurrency_deadlock.rs` verify both simple and complex (3-session) deadlock scenarios, ensuring that one session is always chosen as a victim and the other(s) can proceed.

---
*PR created automatically by Jules for task [8633591954253731591](https://jules.google.com/task/8633591954253731591) started by @celsowm*