### PR TITLE
Implement SET ANSI_DEFAULTS, NOEXEC, PARSEONLY, and dm_exec views

### DIFF
--- a/crates/tsql_core/src/ast/statements/mod.rs
+++ b/crates/tsql_core/src/ast/statements/mod.rs
@@ -139,6 +139,9 @@ pub enum SessionOption {
     StatisticsIo,
     StatisticsTime,
     ShowplanAll,
+    AnsiDefaults,
+    NoExec,
+    ParseOnly,
     Unsupported(String),
 }
 

--- a/crates/tsql_core/src/executor/database/dispatch.rs
+++ b/crates/tsql_core/src/executor/database/dispatch.rs
@@ -436,6 +436,10 @@ where
         return result;
     }
 
+    if session_options.noexec {
+        return Ok(StmtOutcome::Ok(None));
+    }
+
     if tx_manager.active.is_none()
         && session_options.implicit_transactions
         && should_start_implicit_transaction(&stmt)

--- a/crates/tsql_core/src/executor/database/execution.rs
+++ b/crates/tsql_core/src/executor/database/execution.rs
@@ -8,7 +8,7 @@ use super::super::context::ExecutionContext;
 use super::super::locks::SessionId;
 use super::super::result::QueryResult;
 use super::super::session::{SessionRuntime, SharedState};
-use super::super::table_util::is_transaction_statement;
+use super::super::table_util::{is_set_parseonly, is_transaction_statement};
 use super::super::transaction_exec;
 use super::StatementExecutor;
 use super::{EngineCatalog, EngineStorage};
@@ -63,11 +63,33 @@ where
         session_id: SessionId,
         sql: &str,
     ) -> Result<Option<QueryResult>, DbError> {
-        let quoted_ident = with_session(&self.state, session_id, |session| {
-            Ok(session.options.quoted_identifier)
+        let (quoted_ident, mut parse_only) = with_session(&self.state, session_id, |session| {
+            Ok((session.options.quoted_identifier, session.options.parseonly))
         })?;
 
         let stmts = parse_batch_with_quoted_ident(sql, quoted_ident)?;
+
+        let mut final_parse_only = parse_only;
+        let mut changed = false;
+        for stmt in &stmts {
+            if let Some(v) = is_set_parseonly(stmt) {
+                final_parse_only = v;
+                changed = true;
+            }
+        }
+
+        if changed {
+            with_session(&self.state, session_id, |session| {
+                session.options.parseonly = final_parse_only;
+                Ok(())
+            })?;
+            parse_only = final_parse_only;
+        }
+
+        if parse_only {
+            return Ok(None);
+        }
+
         with_session(&self.state, session_id, |session| {
             execute_batch_statements(&self.state, session_id, session, stmts)
         })
@@ -78,11 +100,33 @@ where
         session_id: SessionId,
         sql: &str,
     ) -> Result<Vec<Option<QueryResult>>, DbError> {
-        let quoted_ident = with_session(&self.state, session_id, |session| {
-            Ok(session.options.quoted_identifier)
+        let (quoted_ident, mut parse_only) = with_session(&self.state, session_id, |session| {
+            Ok((session.options.quoted_identifier, session.options.parseonly))
         })?;
 
         let stmts = parse_batch_with_quoted_ident(sql, quoted_ident)?;
+
+        let mut final_parse_only = parse_only;
+        let mut changed = false;
+        for stmt in &stmts {
+            if let Some(v) = is_set_parseonly(stmt) {
+                final_parse_only = v;
+                changed = true;
+            }
+        }
+
+        if changed {
+            with_session(&self.state, session_id, |session| {
+                session.options.parseonly = final_parse_only;
+                Ok(())
+            })?;
+            parse_only = final_parse_only;
+        }
+
+        if parse_only {
+            return Ok(vec![]);
+        }
+
         with_session(&self.state, session_id, |session| {
             execute_batch_statements_multi(&self.state, session_id, session, stmts)
         })

--- a/crates/tsql_core/src/executor/metadata/sys/dm_exec.rs
+++ b/crates/tsql_core/src/executor/metadata/sys/dm_exec.rs
@@ -1,0 +1,289 @@
+use super::super::virtual_table_def;
+use super::super::VirtualTable;
+use crate::catalog::Catalog;
+use crate::storage::StoredRow;
+use crate::types::{DataType, Value};
+
+pub(crate) struct SysDmExecSessions;
+pub(crate) struct SysDmExecConnections;
+pub(crate) struct SysDmExecRequests;
+
+impl VirtualTable for SysDmExecSessions {
+    fn definition(&self) -> crate::catalog::TableDef {
+        virtual_table_def(
+            "dm_exec_sessions",
+            vec![
+                ("session_id", DataType::SmallInt, false),
+                ("login_time", DataType::DateTime, false),
+                ("host_name", DataType::NVarChar { max_len: 128 }, true),
+                ("program_name", DataType::NVarChar { max_len: 128 }, true),
+                ("login_name", DataType::NVarChar { max_len: 128 }, false),
+                ("status", DataType::NVarChar { max_len: 30 }, false),
+                ("cpu_time", DataType::Int, false),
+                ("memory_usage", DataType::Int, false),
+                ("total_scheduled_time", DataType::Int, false),
+                ("total_elapsed_time", DataType::Int, false),
+                ("last_request_start_time", DataType::DateTime, false),
+                ("last_request_end_time", DataType::DateTime, true),
+                ("reads", DataType::BigInt, false),
+                ("writes", DataType::BigInt, false),
+                ("logical_reads", DataType::BigInt, false),
+                ("is_user_process", DataType::Bit, false),
+                ("text_size", DataType::Int, false),
+                ("language", DataType::NVarChar { max_len: 128 }, true),
+                ("date_format", DataType::NVarChar { max_len: 3 }, true),
+                ("date_first", DataType::SmallInt, false),
+                ("quoted_identifier", DataType::Bit, false),
+                ("arithabort", DataType::Bit, false),
+                ("ansi_null_dflt_on", DataType::Bit, false),
+                ("ansi_defaults", DataType::Bit, false),
+                ("ansi_warnings", DataType::Bit, false),
+                ("ansi_padding", DataType::Bit, false),
+                ("ansi_nulls", DataType::Bit, false),
+                ("concat_null_yields_null", DataType::Bit, false),
+                ("transaction_isolation_level", DataType::SmallInt, false),
+                ("lock_timeout", DataType::Int, false),
+                ("deadlock_priority", DataType::Int, false),
+                ("row_count", DataType::BigInt, false),
+                ("prev_error", DataType::Int, false),
+                ("original_login_name", DataType::NVarChar { max_len: 128 }, false),
+                ("database_id", DataType::SmallInt, false),
+                ("open_transaction_count", DataType::Int, false),
+            ],
+        )
+    }
+
+    fn rows(&self, _catalog: &dyn Catalog) -> Vec<StoredRow> {
+        let now = Value::DateTime(
+            chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        );
+        // Return a single row representing the current session shim.
+        // In a real implementation, this would be populated from the engine's session manager.
+        vec![StoredRow {
+            values: vec![
+                Value::SmallInt(51), // session_id
+                now.clone(),        // login_time
+                Value::NVarChar("localhost".to_string()),
+                Value::NVarChar("tsql-wasm".to_string()),
+                Value::NVarChar("sa".to_string()),
+                Value::NVarChar("running".to_string()),
+                Value::Int(0),    // cpu_time
+                Value::Int(1024), // memory_usage
+                Value::Int(0),    // total_scheduled_time
+                Value::Int(0),    // total_elapsed_time
+                now.clone(),      // last_request_start_time
+                Value::Null,      // last_request_end_time
+                Value::BigInt(0), // reads
+                Value::BigInt(0), // writes
+                Value::BigInt(0), // logical_reads
+                Value::Bit(true), // is_user_process
+                Value::Int(4096), // text_size
+                Value::NVarChar("us_english".to_string()),
+                Value::NVarChar("mdy".to_string()),
+                Value::SmallInt(7), // date_first
+                Value::Bit(true),   // quoted_identifier
+                Value::Bit(true),   // arithabort
+                Value::Bit(true),   // ansi_null_dflt_on
+                Value::Bit(false),  // ansi_defaults
+                Value::Bit(true),   // ansi_warnings
+                Value::Bit(true),   // ansi_padding
+                Value::Bit(true),   // ansi_nulls
+                Value::Bit(true),   // concat_null_yields_null
+                Value::SmallInt(2), // transaction_isolation_level (ReadCommitted)
+                Value::Int(-1),     // lock_timeout
+                Value::Int(0),      // deadlock_priority
+                Value::BigInt(0),   // row_count
+                Value::Int(0),      // prev_error
+                Value::NVarChar("sa".to_string()),
+                Value::SmallInt(5), // database_id (tsql_wasm)
+                Value::Int(0),      // open_transaction_count
+            ],
+            deleted: false,
+        }]
+    }
+}
+
+impl VirtualTable for SysDmExecConnections {
+    fn definition(&self) -> crate::catalog::TableDef {
+        virtual_table_def(
+            "dm_exec_connections",
+            vec![
+                ("session_id", DataType::Int, true),
+                ("most_recent_session_id", DataType::Int, true),
+                ("connect_time", DataType::DateTime, false),
+                ("net_transport", DataType::NVarChar { max_len: 40 }, false),
+                ("protocol_type", DataType::NVarChar { max_len: 40 }, true),
+                ("protocol_version", DataType::Int, true),
+                ("endpoint_id", DataType::Int, true),
+                ("encrypt_option", DataType::NVarChar { max_len: 40 }, false),
+                ("auth_scheme", DataType::NVarChar { max_len: 40 }, false),
+                ("node_affinity", DataType::SmallInt, false),
+                ("num_reads", DataType::Int, true),
+                ("num_writes", DataType::Int, true),
+                ("last_read", DataType::DateTime, true),
+                ("last_write", DataType::DateTime, true),
+                ("net_packet_size", DataType::Int, true),
+                ("client_net_address", DataType::VarChar { max_len: 48 }, true),
+                ("client_tcp_port", DataType::Int, true),
+                ("local_net_address", DataType::VarChar { max_len: 48 }, true),
+                ("local_tcp_port", DataType::Int, true),
+                ("connection_id", DataType::UniqueIdentifier, false),
+                ("parent_connection_id", DataType::UniqueIdentifier, true),
+                ("most_recent_sql_handle", DataType::VarBinary { max_len: 64 }, true),
+            ],
+        )
+    }
+
+    fn rows(&self, _catalog: &dyn Catalog) -> Vec<StoredRow> {
+        let now = Value::DateTime(
+            chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        );
+        vec![StoredRow {
+            values: vec![
+                Value::Int(51),
+                Value::Int(51),
+                now.clone(),
+                Value::NVarChar("TCP".to_string()),
+                Value::NVarChar("TSQL".to_string()),
+                Value::Int(0),
+                Value::Int(0),
+                Value::NVarChar("FALSE".to_string()),
+                Value::NVarChar("SQL".to_string()),
+                Value::SmallInt(0),
+                Value::Int(0),
+                Value::Int(0),
+                Value::Null,
+                Value::Null,
+                Value::Int(4096),
+                Value::VarChar("127.0.0.1".to_string()),
+                Value::Int(12345),
+                Value::VarChar("127.0.0.1".to_string()),
+                Value::Int(1433),
+                Value::UniqueIdentifier(uuid::Uuid::nil()),
+                Value::Null,
+                Value::Null,
+            ],
+            deleted: false,
+        }]
+    }
+}
+
+impl VirtualTable for SysDmExecRequests {
+    fn definition(&self) -> crate::catalog::TableDef {
+        virtual_table_def(
+            "dm_exec_requests",
+            vec![
+                ("session_id", DataType::SmallInt, false),
+                ("request_id", DataType::Int, false),
+                ("start_time", DataType::DateTime, false),
+                ("status", DataType::NVarChar { max_len: 30 }, false),
+                ("command", DataType::NVarChar { max_len: 32 }, false),
+                ("sql_handle", DataType::VarBinary { max_len: 64 }, true),
+                ("statement_start_offset", DataType::Int, true),
+                ("statement_end_offset", DataType::Int, true),
+                ("plan_handle", DataType::VarBinary { max_len: 64 }, true),
+                ("database_id", DataType::SmallInt, false),
+                ("user_id", DataType::Int, false),
+                ("connection_id", DataType::UniqueIdentifier, true),
+                ("blocking_session_id", DataType::SmallInt, true),
+                ("wait_type", DataType::NVarChar { max_len: 60 }, true),
+                ("wait_time", DataType::Int, false),
+                ("last_wait_type", DataType::NVarChar { max_len: 60 }, true),
+                ("wait_resource", DataType::NVarChar { max_len: 256 }, true),
+                ("open_transaction_count", DataType::Int, false),
+                ("open_resultset_count", DataType::Int, false),
+                ("transaction_id", DataType::BigInt, false),
+                ("percent_complete", DataType::Float, false),
+                ("estimated_completion_time", DataType::BigInt, false),
+                ("cpu_time", DataType::Int, false),
+                ("total_elapsed_time", DataType::Int, false),
+                ("scheduler_id", DataType::Int, true),
+                ("reads", DataType::BigInt, false),
+                ("writes", DataType::BigInt, false),
+                ("logical_reads", DataType::BigInt, false),
+                ("text_size", DataType::Int, false),
+                ("language", DataType::NVarChar { max_len: 128 }, true),
+                ("date_format", DataType::NVarChar { max_len: 3 }, true),
+                ("date_first", DataType::SmallInt, false),
+                ("quoted_identifier", DataType::Bit, false),
+                ("arithabort", DataType::Bit, false),
+                ("ansi_null_dflt_on", DataType::Bit, false),
+                ("ansi_defaults", DataType::Bit, false),
+                ("ansi_warnings", DataType::Bit, false),
+                ("ansi_padding", DataType::Bit, false),
+                ("ansi_nulls", DataType::Bit, false),
+                ("concat_null_yields_null", DataType::Bit, false),
+                ("transaction_isolation_level", DataType::SmallInt, false),
+                ("lock_timeout", DataType::Int, false),
+                ("deadlock_priority", DataType::Int, false),
+                ("row_count", DataType::BigInt, false),
+                ("prev_error", DataType::Int, false),
+            ],
+        )
+    }
+
+    fn rows(&self, _catalog: &dyn Catalog) -> Vec<StoredRow> {
+        let now = Value::DateTime(
+            chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        );
+        vec![StoredRow {
+            values: vec![
+                Value::SmallInt(51),
+                Value::Int(0),
+                now.clone(),
+                Value::NVarChar("running".to_string()),
+                Value::NVarChar("SELECT".to_string()),
+                Value::Null,
+                Value::Null,
+                Value::Null,
+                Value::Null,
+                Value::SmallInt(5),
+                Value::Int(1),
+                Value::UniqueIdentifier(uuid::Uuid::nil()),
+                Value::Null,
+                Value::Null,
+                Value::Int(0),
+                Value::Null,
+                Value::Null,
+                Value::Int(0),
+                Value::Int(1),
+                Value::BigInt(0),
+                Value::Float(0f64.to_bits()),
+                Value::BigInt(0),
+                Value::Int(0),
+                Value::Int(0),
+                Value::Int(1),
+                Value::BigInt(0),
+                Value::BigInt(0),
+                Value::BigInt(0),
+                Value::Int(4096),
+                Value::NVarChar("us_english".to_string()),
+                Value::NVarChar("mdy".to_string()),
+                Value::SmallInt(7),
+                Value::Bit(true),
+                Value::Bit(true),
+                Value::Bit(true),
+                Value::Bit(false),
+                Value::Bit(true),
+                Value::Bit(true),
+                Value::Bit(true),
+                Value::Bit(true),
+                Value::SmallInt(2),
+                Value::Int(-1),
+                Value::Int(0),
+                Value::BigInt(0),
+                Value::Int(0),
+            ],
+            deleted: false,
+        }]
+    }
+}

--- a/crates/tsql_core/src/executor/metadata/sys/mod.rs
+++ b/crates/tsql_core/src/executor/metadata/sys/mod.rs
@@ -1,4 +1,5 @@
 mod constraints;
+mod dm_exec;
 mod hadr;
 mod host_info;
 mod indexes;
@@ -86,6 +87,12 @@ pub(crate) fn lookup(schema: &str, name: &str) -> Option<Box<dyn VirtualTable>> 
         Some(Box::new(objects::SysSystemViews))
     } else if name.eq_ignore_ascii_case("dm_os_host_info") {
         Some(Box::new(host_info::SysHostInfo))
+    } else if name.eq_ignore_ascii_case("dm_exec_sessions") {
+        Some(Box::new(dm_exec::SysDmExecSessions))
+    } else if name.eq_ignore_ascii_case("dm_exec_connections") {
+        Some(Box::new(dm_exec::SysDmExecConnections))
+    } else if name.eq_ignore_ascii_case("dm_exec_requests") {
+        Some(Box::new(dm_exec::SysDmExecRequests))
     } else if name.eq_ignore_ascii_case("check_constraints") {
         Some(Box::new(constraints::SysCheckConstraints))
     } else if name.eq_ignore_ascii_case("routines") {

--- a/crates/tsql_core/src/executor/table_util.rs
+++ b/crates/tsql_core/src/executor/table_util.rs
@@ -172,3 +172,14 @@ pub(crate) fn is_transaction_statement(stmt: &Statement) -> bool {
             ))
     )
 }
+
+pub(crate) fn is_set_parseonly(stmt: &Statement) -> Option<bool> {
+    if let Statement::Session(crate::ast::SessionStatement::SetOption(opt)) = stmt {
+        if let (crate::ast::SessionOption::ParseOnly, crate::ast::SessionOptionValue::Bool(v)) =
+            (&opt.option, &opt.value)
+        {
+            return Some(*v);
+        }
+    }
+    None
+}

--- a/crates/tsql_core/src/executor/tooling/session_options.rs
+++ b/crates/tsql_core/src/executor/tooling/session_options.rs
@@ -29,6 +29,8 @@ pub struct SessionOptions {
     pub statistics_io: bool,
     pub statistics_time: bool,
     pub showplan_all: bool,
+    pub noexec: bool,
+    pub parseonly: bool,
     #[serde(skip)]
     pub identity_insert: HashSet<String>,
 }
@@ -58,6 +60,8 @@ impl Default for SessionOptions {
             statistics_io: false,
             statistics_time: false,
             showplan_all: false,
+            noexec: false,
+            parseonly: false,
             identity_insert: HashSet::new(),
         }
     }
@@ -167,6 +171,22 @@ pub fn apply_set_option(
         }
         (SessionOption::ShowplanAll, SessionOptionValue::Bool(v)) => {
             options.showplan_all = *v;
+        }
+        (SessionOption::NoExec, SessionOptionValue::Bool(v)) => {
+            options.noexec = *v;
+        }
+        (SessionOption::ParseOnly, SessionOptionValue::Bool(v)) => {
+            options.parseonly = *v;
+        }
+        (SessionOption::AnsiDefaults, SessionOptionValue::Bool(v)) => {
+            options.ansi_nulls = *v;
+            options.quoted_identifier = *v;
+            options.ansi_null_dflt_on = *v;
+            options.ansi_padding = *v;
+            options.ansi_warnings = *v;
+            options.arithabort = *v;
+            options.cursor_close_on_commit = *v;
+            options.implicit_transactions = *v;
         }
         (SessionOption::Unsupported(name), _) => {
             warnings.push(format!(

--- a/crates/tsql_core/src/parser/ast/statements/other.rs
+++ b/crates/tsql_core/src/parser/ast/statements/other.rs
@@ -442,6 +442,9 @@ pub enum SessionOption {
     StatisticsIo,
     StatisticsTime,
     ShowplanAll,
+    AnsiDefaults,
+    NoExec,
+    ParseOnly,
     Unsupported(String),
 }
 

--- a/crates/tsql_core/src/parser/lower/procedural.rs
+++ b/crates/tsql_core/src/parser/lower/procedural.rs
@@ -342,6 +342,9 @@ pub fn lower_session(session: ast::SessionStatement) -> Result<executor_ast::Sta
                             executor_ast::SessionOption::StatisticsTime
                         }
                         ast::SessionOption::ShowplanAll => executor_ast::SessionOption::ShowplanAll,
+                        ast::SessionOption::AnsiDefaults => executor_ast::SessionOption::AnsiDefaults,
+                        ast::SessionOption::NoExec => executor_ast::SessionOption::NoExec,
+                        ast::SessionOption::ParseOnly => executor_ast::SessionOption::ParseOnly,
                         ast::SessionOption::Unsupported(v) => {
                             executor_ast::SessionOption::Unsupported(v)
                         }

--- a/crates/tsql_core/src/parser/parse/mod.rs
+++ b/crates/tsql_core/src/parser/parse/mod.rs
@@ -603,6 +603,16 @@ fn parse_set_dispatch(parser: &mut Parser) -> ParseResult<Statement> {
         }
     }
 
+    if matches_set_name(parser.peek(), "ANSI_DEFAULTS") {
+        return parse_bool_setting(parser, crate::parser::ast::SessionOption::AnsiDefaults);
+    }
+    if matches_set_name(parser.peek(), "NOEXEC") {
+        return parse_bool_setting(parser, crate::parser::ast::SessionOption::NoExec);
+    }
+    if matches_set_name(parser.peek(), "PARSEONLY") {
+        return parse_bool_setting(parser, crate::parser::ast::SessionOption::ParseOnly);
+    }
+
     if let Some(tok) = parser.peek() {
         let option_name = match tok {
             Token::Identifier(id) => Some(id.clone()),

--- a/crates/tsql_core/tests/roadmap_dm_exec_and_sets.rs
+++ b/crates/tsql_core/tests/roadmap_dm_exec_and_sets.rs
@@ -1,0 +1,118 @@
+use tsql_core::{Database, SessionManager, StatementExecutor};
+
+#[test]
+fn test_ansi_defaults_shortcut() {
+    let db = Database::new();
+    let session_id = db.create_session();
+
+    // Verify initial defaults
+    let opts = db.session_options(session_id).unwrap();
+    assert_eq!(opts.ansi_nulls, true);
+    assert_eq!(opts.implicit_transactions, false);
+
+    // Turn ANSI_DEFAULTS ON
+    db.execute_session_batch_sql(session_id, "SET ANSI_DEFAULTS ON")
+        .unwrap();
+    let opts = db.session_options(session_id).unwrap();
+    assert_eq!(opts.ansi_nulls, true);
+    assert_eq!(opts.quoted_identifier, true);
+    assert_eq!(opts.ansi_null_dflt_on, true);
+    assert_eq!(opts.ansi_padding, true);
+    assert_eq!(opts.ansi_warnings, true);
+    assert_eq!(opts.arithabort, true);
+    assert_eq!(opts.cursor_close_on_commit, true);
+    assert_eq!(opts.implicit_transactions, true);
+
+    // Turn ANSI_DEFAULTS OFF
+    db.execute_session_batch_sql(session_id, "SET ANSI_DEFAULTS OFF")
+        .unwrap();
+    let opts = db.session_options(session_id).unwrap();
+    assert_eq!(opts.ansi_nulls, false);
+    assert_eq!(opts.implicit_transactions, false);
+}
+
+#[test]
+fn test_noexec_and_parseonly_options() {
+    let db = Database::new();
+    let session_id = db.create_session();
+
+    db.execute_session_batch_sql(session_id, "SET NOEXEC ON")
+        .unwrap();
+    let opts = db.session_options(session_id).unwrap();
+    assert_eq!(opts.noexec, true);
+
+    db.execute_session_batch_sql(session_id, "SET PARSEONLY ON")
+        .unwrap();
+    let opts = db.session_options(session_id).unwrap();
+    assert_eq!(opts.parseonly, true);
+}
+
+#[test]
+fn test_noexec_prevents_execution() {
+    let db = Database::new();
+    let session_id = db.create_session();
+
+    db.execute_session_batch_sql(session_id, "CREATE TABLE T(A INT)").unwrap();
+    db.execute_session_batch_sql(session_id, "SET NOEXEC ON").unwrap();
+
+    // This should NOT insert anything
+    db.execute_session_batch_sql(session_id, "INSERT INTO T VALUES(1)").unwrap();
+
+    db.execute_session_batch_sql(session_id, "SET NOEXEC OFF").unwrap();
+    let res = db.execute_session_batch_sql(session_id, "SELECT COUNT(*) FROM T").unwrap().expect("should return result");
+    assert_eq!(res.rows[0][0].to_integer_i64(), Some(0));
+}
+
+#[test]
+fn test_parseonly_prevents_execution_of_batch() {
+    let db = Database::new();
+    let session_id = db.create_session();
+
+    db.execute_session_batch_sql(session_id, "CREATE TABLE T(A INT)").unwrap();
+
+    // Verify SELECT works
+    let _ = db.execute_session_batch_sql(session_id, "SELECT COUNT(*) FROM T").unwrap().expect("SELECT should work here");
+
+    // Batch that turns PARSEONLY ON should not execute any of its statements
+    let res = db.execute_session_batch_sql(session_id, "INSERT INTO T VALUES(1); SET PARSEONLY ON; INSERT INTO T VALUES(2)").unwrap();
+    assert!(res.is_none(), "Batch with PARSEONLY ON should return None");
+
+    // Verify T is still empty
+    let res = db.execute_session_batch_sql(session_id, "SELECT COUNT(*) FROM T").unwrap();
+    assert!(res.is_none(), "Subsequent SELECT should return None when PARSEONLY is ON");
+
+    // Turn it off
+    let _ = db.execute_session_batch_sql(session_id, "SET PARSEONLY OFF").unwrap();
+
+    // NOW it should work
+    db.execute_session_batch_sql(session_id, "INSERT INTO T VALUES(4)").unwrap();
+    let res = db.execute_session_batch_sql(session_id, "SELECT COUNT(*) FROM T").unwrap().expect("Should return result now");
+    assert_eq!(res.rows[0][0].to_integer_i64(), Some(1));
+}
+
+#[test]
+fn test_dm_exec_views_present() {
+    let db = Database::new();
+    let session_id = db.create_session();
+
+    let res = db
+        .execute_session_batch_sql(session_id, "SELECT session_id FROM sys.dm_exec_sessions")
+        .unwrap();
+    assert!(res.is_some());
+    let qr = res.unwrap();
+    assert!(!qr.rows.is_empty());
+
+    let res = db
+        .execute_session_batch_sql(session_id, "SELECT session_id FROM sys.dm_exec_connections")
+        .unwrap();
+    assert!(res.is_some());
+    let qr = res.unwrap();
+    assert!(!qr.rows.is_empty());
+
+    let res = db
+        .execute_session_batch_sql(session_id, "SELECT session_id FROM sys.dm_exec_requests")
+        .unwrap();
+    assert!(res.is_some());
+    let qr = res.unwrap();
+    assert!(!qr.rows.is_empty());
+}


### PR DESCRIPTION
This change implements several items from the T-SQL compatibility roadmap, specifically focusing on session configuration options and Dynamic Management Views (DMVs).

Key changes:
1.  **Session Options**:
    *   Implemented `SET ANSI_DEFAULTS`, which toggles multiple underlying settings (`ANSI_NULLS`, `QUOTED_IDENTIFIER`, etc.) to align with standard SQL Server behavior.
    *   Implemented `SET NOEXEC`, allowing scripts to be submitted without execution while still applying state changes.
    *   Implemented `SET PARSEONLY` with "parse-time" semantics, ensuring batches are parsed but not executed if the option is enabled.
2.  **Metadata Fidelity (DMVs)**:
    *   Added `sys.dm_exec_sessions`, `sys.dm_exec_connections`, and `sys.dm_exec_requests` as compatible shims. These views return the column sets expected by common T-SQL monitoring tools.
3.  **Engine Support**:
    *   Updated the statement dispatcher and batch execution logic to respect the new execution gates.
    *   Extended the AST and session runtime state to track these new options.

Integration tests in `crates/tsql_core/tests/roadmap_dm_exec_and_sets.rs` verify the end-to-end behavior of these changes.

---
*PR created automatically by Jules for task [9326380350446807876](https://jules.google.com/task/9326380350446807876) started by @celsowm*