### PR TITLE
[codex] Add Windows release packaging

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,82 @@
+name: Windows Release
+
+on:
+  push:
+    tags:
+      - "v*-windows.*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Windows release tag to use for artifact names
+        required: true
+        default: v0.1.0-windows.1
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+          key: windows-release
+
+      - name: Build release binaries
+        shell: pwsh
+        run: |
+          cargo build --locked --release -p iridium_server --bin iridium-server --bin compat-query --target x86_64-pc-windows-msvc
+
+      - name: Install WiX Toolset
+        shell: pwsh
+        run: |
+          choco install wixtoolset --no-progress -y
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\WiX Toolset v3.11\bin"
+
+      - name: Package Windows release
+        shell: pwsh
+        run: |
+          $releaseTag = "${{ github.ref_name }}"
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $releaseTag = "${{ inputs.release_tag }}"
+          }
+          ./scripts/package-windows-release.ps1 -ReleaseTag $releaseTag -TargetTriple x86_64-pc-windows-msvc
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: iridium-sql-windows-release
+          path: dist/windows/*
+
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/windows/*.zip
+            dist/windows/*.msi
+            dist/windows/*.txt
+          body: |
+            Windows packaging release for Iridium SQL.
+
+            Artifacts:
+            - Portable ZIP bundle
+            - Per-machine MSI installer
+            - SHA256 checksum file
+
+            Notes:
+            - x64 only
+            - no Windows service
+            - MSI installs under Program Files
+            - persistent data defaults to ProgramData\Iridium SQL

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Iridium SQL contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Run in ephemeral mode:
 cargo run --package iridium_server --bin iridium-server -- --memory
 ```
 
+On Windows, persistent data defaults to `%ProgramData%\Iridium SQL\iridium_sql_data`.
+Use `--data-dir <PATH>` to override it, or the portable ZIP's
+`start-iridium-server-portable.cmd` to keep data next to the extracted bundle.
+
 Build the WASM package:
 
 ```bash

--- a/crates/iridium_server/bin/main.rs
+++ b/crates/iridium_server/bin/main.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::PathBuf;
 
 use iridium_core::{Database, PersistentDatabase};
 use iridium_server::{playground, Credentials, ServerConfig, TdsServer};
@@ -54,6 +54,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 i += 1;
                 config.database = args.get(i).cloned().unwrap_or_default();
                 database_arg_provided = true;
+            }
+            "--data-dir" => {
+                i += 1;
+                if let Some(path) = args.get(i) {
+                    config.data_dir = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Error: --data-dir requires a path argument.");
+                    std::process::exit(1);
+                }
             }
             "--pool-min" => {
                 i += 1;
@@ -157,14 +166,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     );
     log::info!("Database: {}", config.database);
-    log::info!(
-        "Storage: {}",
-        if memory_mode {
-            "memory (ephemeral)"
-        } else {
-            "persistent (./iridium_sql_data)"
-        }
-    );
+    let storage_description = if memory_mode {
+        "memory (ephemeral)".to_string()
+    } else {
+        format!("persistent ({})", config.resolved_data_dir().display())
+    };
+    log::info!("Storage: {}", storage_description);
     log::info!(
         "Session pool: min={}, max={}, idle_timeout={}s",
         config.pool_min_size,
@@ -186,7 +193,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         TdsServer::new_with_database(db, config)
     } else {
-        let db = PersistentDatabase::new_persistent(Path::new("iridium_sql_data"))?;
+        let db = PersistentDatabase::new_persistent(&config.resolved_data_dir())?;
         if playground_mode {
             log::info!("Starting in PLAYGROUND mode...");
             log::info!("Seeding database with sample tables, views, and data...");
@@ -272,6 +279,7 @@ fn print_help() {
     println!("  --user, -u <USER>       Username for authentication (optional)");
     println!("  --password, -P <PASS>   Password for authentication (optional)");
     println!("  --database, -d <DB>     Default database name (default: master)");
+    println!("  --data-dir <PATH>       Directory for persistent storage");
     println!("  --pool-min <N>          Minimum pooled sessions to keep ready (default: 1)");
     println!("  --pool-max <N>          Maximum pooled sessions allowed (default: 50)");
     println!("  --pool-idle-timeout <S> Idle timeout in seconds for extra sessions (default: 300)");
@@ -300,7 +308,7 @@ fn print_help() {
     println!();
     println!("NOTES:");
     println!("  - TLS is enabled by default");
-    println!("  - Storage defaults to ./iridium_sql_data unless --memory is set");
+    println!("  - Storage defaults to ProgramData on Windows and ./iridium_sql_data elsewhere");
+    println!("  - Use --data-dir to override the persistent storage path");
     println!("  - Use --tls-gen to generate a self-signed certificate for testing");
 }
-

--- a/crates/iridium_server/src/lib.rs
+++ b/crates/iridium_server/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub mod playground;
 pub mod pool;
 pub mod server;
@@ -33,6 +35,7 @@ pub struct ServerConfig {
     pub pool_min_size: usize,
     pub pool_max_size: usize,
     pub pool_idle_timeout_secs: u64,
+    pub data_dir: Option<PathBuf>,
 }
 
 impl Default for ServerConfig {
@@ -49,6 +52,7 @@ impl Default for ServerConfig {
             pool_min_size: 1,
             pool_max_size: 50,
             pool_idle_timeout_secs: 300,
+            data_dir: None,
         }
     }
 }
@@ -113,4 +117,26 @@ impl ServerConfig {
         self.pool_idle_timeout_secs = secs;
         self
     }
+
+    pub fn data_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.data_dir = Some(path.into());
+        self
+    }
+
+    pub fn resolved_data_dir(&self) -> PathBuf {
+        self.data_dir.clone().unwrap_or_else(default_data_dir)
+    }
+}
+
+pub fn default_data_dir() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(program_data) = std::env::var_os("ProgramData") {
+            return PathBuf::from(program_data)
+                .join("Iridium SQL")
+                .join("iridium_sql_data");
+        }
+    }
+
+    PathBuf::from("iridium_sql_data")
 }

--- a/crates/iridium_server/src/server.rs
+++ b/crates/iridium_server/src/server.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 
@@ -19,9 +18,10 @@ pub struct TdsServer {
 impl TdsServer {
     pub fn new(config: ServerConfig) -> Self {
         let session_pool = Arc::new(SessionPool::from_config(&config));
+        let data_dir = config.resolved_data_dir();
         Self {
             db: Arc::new(
-                PersistentDatabase::new_persistent(Path::new("iridium_sql_data"))
+                PersistentDatabase::new_persistent(&data_dir)
                     .expect("failed to initialize persistent database"),
             ),
             config: Arc::new(config),
@@ -114,4 +114,3 @@ impl TdsServer {
         Ok(())
     }
 }
-

--- a/crates/iridium_server/tests/catalog_rpc.rs
+++ b/crates/iridium_server/tests/catalog_rpc.rs
@@ -45,6 +45,7 @@ async fn start_server() -> u16 {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
 
     let mut server = TdsServer::new_with_database(Database::new(), config);

--- a/crates/iridium_server/tests/common/mod.rs
+++ b/crates/iridium_server/tests/common/mod.rs
@@ -56,6 +56,7 @@ pub async fn start_server() -> u16 {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
     start_server_with_config(config).await
 }
@@ -148,4 +149,3 @@ pub async fn exec_sql(client: &mut Client<tokio_util::compat::Compat<TcpStream>>
         .await
         .expect(&format!("Execute failed: {}", sql));
 }
-

--- a/crates/iridium_server/tests/compatibility.rs
+++ b/crates/iridium_server/tests/compatibility.rs
@@ -122,6 +122,7 @@ async fn test_database_context_tracks_login_database() {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     })
     .await;
     let mut client = connect(port).await;
@@ -165,4 +166,3 @@ async fn test_object_explorer_srvrolemember_probe() {
     let roles_mask: i32 = rows[0].try_get(0).unwrap().unwrap();
     assert_eq!(roles_mask, 1);
 }
-

--- a/crates/iridium_server/tests/cursor_compare_test.rs
+++ b/crates/iridium_server/tests/cursor_compare_test.rs
@@ -62,6 +62,7 @@ async fn start_local_server() -> u16 {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
 
     let mut server = TdsServer::new_with_database(Database::new(), config);
@@ -324,4 +325,3 @@ async fn test_compare_cursor_aggregation() {
     // Cleanup
     azure.execute("DROP TABLE dbo.agg_cursor", &[]).await.unwrap();
 }
-

--- a/crates/iridium_server/tests/playground.rs
+++ b/crates/iridium_server/tests/playground.rs
@@ -21,6 +21,7 @@ async fn test_playground_tables() {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
 
     let db = iridium_core::Database::new();
@@ -61,4 +62,3 @@ async fn test_playground_tables() {
     assert_eq!(cols[1], "TotalOrders");
     assert_eq!(rows.len(), 2);
 }
-

--- a/crates/iridium_server/tests/pool.rs
+++ b/crates/iridium_server/tests/pool.rs
@@ -21,6 +21,7 @@ async fn test_session_pool_reuse_resets_session_state() {
         pool_min_size: 1,
         pool_max_size: 1,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
 
     let port = start_server_with_config(config).await;
@@ -59,6 +60,7 @@ async fn test_session_pool_max_size_enforced() {
         pool_min_size: 0,
         pool_max_size: 1,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
 
     let port = start_server_with_config(config).await;
@@ -80,4 +82,3 @@ async fn test_session_pool_max_size_enforced() {
 
     assert!(result.is_err());
 }
-

--- a/crates/iridium_server/tests/security.rs
+++ b/crates/iridium_server/tests/security.rs
@@ -24,6 +24,7 @@ async fn test_auth_reject() {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
 
     let mut server = TdsServer::new_with_database(Database::new(), config);
@@ -69,6 +70,7 @@ async fn test_auth_accept() {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
 
     let mut server = TdsServer::new_with_database(Database::new(), config);
@@ -100,4 +102,3 @@ async fn test_auth_accept() {
     let (_, rows) = query_sql(&mut client, "SELECT 99 as val").await;
     assert_eq!(rows[0][0], "99");
 }
-

--- a/crates/iridium_server_test_support/src/lib.rs
+++ b/crates/iridium_server_test_support/src/lib.rs
@@ -56,6 +56,7 @@ pub async fn start_server() -> u16 {
         pool_min_size: 1,
         pool_max_size: 50,
         pool_idle_timeout_secs: 300,
+        data_dir: None,
     };
     start_server_with_config(config).await
 }
@@ -147,4 +148,3 @@ pub async fn exec_sql(client: &mut Client<tokio_util::compat::Compat<TcpStream>>
         .await
         .unwrap_or_else(|_| panic!("Execute failed: {}", sql));
 }
-

--- a/packaging/windows/INSTALL.txt
+++ b/packaging/windows/INSTALL.txt
@@ -1,0 +1,22 @@
+Iridium SQL for Windows
+
+This package contains:
+- iridium-server.exe
+- compat-query.exe
+- README.md
+- LICENSE
+- this install note
+
+MSI install behavior:
+- per-machine install under Program Files
+- Start Menu shortcuts for the server and compatibility query helper
+- persistent data defaults to %ProgramData%\Iridium SQL\iridium_sql_data
+
+Portable ZIP behavior:
+- unzip anywhere and run start-iridium-server-portable.cmd
+- that launcher keeps data inside the extracted folder under .\data
+
+Runtime notes:
+- use --memory for ephemeral storage
+- use --data-dir <PATH> to override the persistent storage location
+- the server remains SQL Server-compatible; SQL Server is a trademark of Microsoft

--- a/packaging/windows/iridium-sql.wxs
+++ b/packaging/windows/iridium-sql.wxs
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product
+    Id="*"
+    Name="Iridium SQL"
+    Language="1033"
+    Version="$(var.ProductVersion)"
+    Manufacturer="Iridium SQL"
+    UpgradeCode="D19E7E0B-0F3E-4A97-8E44-04C3B8BDBB2A">
+    <Package
+      InstallerVersion="500"
+      Compressed="yes"
+      InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <Feature Id="MainFeature" Title="Iridium SQL" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+
+    <UIRef Id="WixUI_InstallDir" />
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    <Property Id="ARPNOREPAIR" Value="yes" />
+    <Property Id="ARPNOMODIFY" Value="yes" />
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFiles64Folder">
+        <Directory Id="INSTALLFOLDER" Name="Iridium SQL" />
+      </Directory>
+      <Directory Id="CommonAppDataFolder">
+        <Directory Id="COMMONAPPDATAIRIDIUM" Name="Iridium SQL">
+          <Directory Id="COMMONAPPDATAIRIDIUMDATA" Name="iridium_sql_data" />
+        </Directory>
+      </Directory>
+      <Directory Id="ProgramMenuFolder">
+        <Directory Id="APPLICATIONPROGRAMS" Name="Iridium SQL" />
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductComponents">
+      <ComponentRef Id="IridiumServerExeComponent" />
+      <ComponentRef Id="CompatQueryExeComponent" />
+      <ComponentRef Id="ReadmeComponent" />
+      <ComponentRef Id="LicenseComponent" />
+      <ComponentRef Id="InstallNotesComponent" />
+      <ComponentRef Id="DataDirectoryComponent" />
+      <ComponentRef Id="StartMenuComponent" />
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <DirectoryRef Id="INSTALLFOLDER">
+      <Component Id="IridiumServerExeComponent" Guid="5A92D0EA-68C1-4B31-8A68-7B8F0E0EDC1B">
+        <File Id="IridiumServerExe" Source="$(var.SourceDir)\iridium-server.exe" KeyPath="yes" />
+      </Component>
+
+      <Component Id="CompatQueryExeComponent" Guid="3A347C3D-08B8-4E9D-90D7-196C0A3E1C5A">
+        <File Id="CompatQueryExe" Source="$(var.SourceDir)\compat-query.exe" KeyPath="yes" />
+      </Component>
+
+      <Component Id="ReadmeComponent" Guid="CCF0F4A1-1FBF-4D04-93B2-7F7EED3B38A7">
+        <File Id="ReadmeFile" Source="$(var.SourceDir)\README.md" KeyPath="yes" />
+      </Component>
+
+      <Component Id="LicenseComponent" Guid="B0DD23C8-1F66-4B56-A8FB-8F2D2D69A47A">
+        <File Id="LicenseFile" Source="$(var.SourceDir)\LICENSE" KeyPath="yes" />
+      </Component>
+
+      <Component Id="InstallNotesComponent" Guid="9B5F9D71-4E6B-4D5A-871A-4A6B0E9ED5C3">
+        <File Id="InstallNotesFile" Source="$(var.SourceDir)\INSTALL.txt" KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="COMMONAPPDATAIRIDIUMDATA">
+      <Component Id="DataDirectoryComponent" Guid="E5E79E7C-4B56-41B5-9A95-DB0C9C0F8D2E">
+        <CreateFolder />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="APPLICATIONPROGRAMS">
+      <Component Id="StartMenuComponent" Guid="8E6E72A0-4B0B-48D7-8F49-6A0C6C8B8C6D">
+        <Shortcut
+          Id="StartServerShortcut"
+          Name="Iridium SQL Server"
+          Description="Start the Iridium SQL TDS server"
+          Target="[INSTALLFOLDER]iridium-server.exe"
+          WorkingDirectory="INSTALLFOLDER" />
+        <Shortcut
+          Id="CompatQueryShortcut"
+          Name="Iridium SQL Compatibility Query"
+          Description="Run a compatibility query against Iridium SQL"
+          Target="[INSTALLFOLDER]compat-query.exe"
+          WorkingDirectory="INSTALLFOLDER" />
+        <RemoveFolder Id="RemoveApplicationPrograms" Directory="APPLICATIONPROGRAMS" On="uninstall" />
+        <RegistryValue Root="HKLM" Key="Software\Iridium SQL" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/packaging/windows/portable-run.cmd
+++ b/packaging/windows/portable-run.cmd
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+
+set "IRIDIUM_SQL_DATA_DIR=%~dp0data"
+if not exist "%IRIDIUM_SQL_DATA_DIR%" mkdir "%IRIDIUM_SQL_DATA_DIR%"
+
+"%~dp0iridium-server.exe" %*

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -1,0 +1,115 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseTag,
+    [string]$TargetTriple = "x86_64-pc-windows-msvc",
+    [string]$WorkspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [string]$OutputDir = (Join-Path (Resolve-Path (Join-Path $PSScriptRoot "..")).Path "dist\windows")
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function New-CleanDirectory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (Test-Path $Path) {
+        Remove-Item -Path $Path -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+}
+
+function Copy-RequiredFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    if (-not (Test-Path $Source)) {
+        throw "Required file not found: $Source"
+    }
+
+    Copy-Item -Path $Source -Destination $Destination -Force
+}
+
+$match = [regex]::Match($ReleaseTag, '^v?(?<base>\d+\.\d+\.\d+)(?:-windows\.(?<build>\d+))?$')
+if (-not $match.Success) {
+    throw "ReleaseTag '$ReleaseTag' must look like v0.1.0-windows.1"
+}
+
+$baseVersion = $match.Groups['base'].Value
+$productVersion = $baseVersion
+
+$artifactStem = "IridiumSQL-$ReleaseTag-x64"
+$portableRoot = Join-Path $OutputDir "portable"
+$portableStage = Join-Path $portableRoot $artifactStem
+$msiStage = Join-Path $OutputDir "msi-stage"
+$zipPath = Join-Path $OutputDir "$artifactStem.zip"
+$msiPath = Join-Path $OutputDir "$artifactStem.msi"
+$checksumPath = Join-Path $OutputDir "$artifactStem.sha256.txt"
+
+$buildOutput = Join-Path $WorkspaceRoot "target\$TargetTriple\release"
+$serverExe = Join-Path $buildOutput "iridium-server.exe"
+$compatQueryExe = Join-Path $buildOutput "compat-query.exe"
+
+$readme = Join-Path $WorkspaceRoot "README.md"
+$license = Join-Path $WorkspaceRoot "LICENSE"
+$installNotes = Join-Path $WorkspaceRoot "packaging\windows\INSTALL.txt"
+$portableLauncher = Join-Path $WorkspaceRoot "packaging\windows\portable-run.cmd"
+$wixSource = Join-Path $WorkspaceRoot "packaging\windows\iridium-sql.wxs"
+
+foreach ($required in @($serverExe, $compatQueryExe, $readme, $license, $installNotes, $portableLauncher, $wixSource)) {
+    if (-not (Test-Path $required)) {
+        throw "Missing required input: $required"
+    }
+}
+
+New-CleanDirectory -Path $OutputDir
+New-CleanDirectory -Path $portableStage
+New-CleanDirectory -Path $msiStage
+
+Copy-RequiredFile -Source $serverExe -Destination (Join-Path $portableStage "iridium-server.exe")
+Copy-RequiredFile -Source $compatQueryExe -Destination (Join-Path $portableStage "compat-query.exe")
+Copy-RequiredFile -Source $readme -Destination (Join-Path $portableStage "README.md")
+Copy-RequiredFile -Source $license -Destination (Join-Path $portableStage "LICENSE")
+Copy-RequiredFile -Source $installNotes -Destination (Join-Path $portableStage "INSTALL.txt")
+Copy-RequiredFile -Source $portableLauncher -Destination (Join-Path $portableStage "start-iridium-server-portable.cmd")
+
+Copy-RequiredFile -Source $serverExe -Destination (Join-Path $msiStage "iridium-server.exe")
+Copy-RequiredFile -Source $compatQueryExe -Destination (Join-Path $msiStage "compat-query.exe")
+Copy-RequiredFile -Source $readme -Destination (Join-Path $msiStage "README.md")
+Copy-RequiredFile -Source $license -Destination (Join-Path $msiStage "LICENSE")
+Copy-RequiredFile -Source $installNotes -Destination (Join-Path $msiStage "INSTALL.txt")
+
+Compress-Archive -Path (Join-Path $portableStage "*") -DestinationPath $zipPath -Force
+
+$candle = (Get-Command candle.exe -ErrorAction Stop).Path
+$light = (Get-Command light.exe -ErrorAction Stop).Path
+$wixObj = Join-Path $OutputDir "iridium-sql.wixobj"
+
+& $candle -nologo -arch x64 -dSourceDir="$msiStage" -dProductVersion="$productVersion" -out "$wixObj" "$wixSource"
+if ($LASTEXITCODE -ne 0) {
+    throw "WiX candle failed with exit code $LASTEXITCODE"
+}
+
+& $light -nologo -ext WixUIExtension -cultures:en-us -out "$msiPath" "$wixObj"
+if ($LASTEXITCODE -ne 0) {
+    throw "WiX light failed with exit code $LASTEXITCODE"
+}
+
+$hashLines = @()
+foreach ($artifact in @($zipPath, $msiPath)) {
+    $hash = (Get-FileHash -Path $artifact -Algorithm SHA256).Hash.ToLowerInvariant()
+    $hashLines += "$hash  $(Split-Path $artifact -Leaf)"
+}
+
+$hashLines | Set-Content -Path $checksumPath -Encoding ASCII
+
+Remove-Item -Path $portableRoot -Recurse -Force
+Remove-Item -Path $msiStage -Recurse -Force
+Remove-Item -Path $wixObj -Force
+
+Write-Host "Created artifacts:"
+Write-Host "  $zipPath"
+Write-Host "  $msiPath"
+Write-Host "  $checksumPath"


### PR DESCRIPTION
## Summary
Add the first Windows distribution for Iridium SQL as a packaging-only release.

## What changed
- Added a GitHub Actions workflow for Windows release builds
- Added portable ZIP packaging for `iridium-server` and `compat-query`
- Added a per-machine MSI installer via WiX
- Added packaging notes and a lightweight Windows launcher
- Made the server storage directory configurable and default to ProgramData on Windows

## Notes
- x64 only for the first drop
- no Windows service in v1
- unsigned release unless signing infrastructure is available
- release tag target: `v0.1.0-windows.1`

## Validation
- `cargo test -p iridium_server --no-run`
