### PR TITLE
[codex] add synchronized version bump automation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_dir=$(git rev-parse --show-toplevel)
+
+exec node "$repo_dir/scripts/version-sync.mjs" bump

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,89 @@
+name: Publish crates.io packages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-crates-main
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      shared_version: ${{ steps.status.outputs.shared_version }}
+      any_crates_should_publish: ${{ steps.status.outputs.any_crates_should_publish }}
+      iridium_core_should_publish: ${{ steps.status.outputs.iridium_core_should_publish }}
+      iridium_server_should_publish: ${{ steps.status.outputs.iridium_server_should_publish }}
+      iridium_wasm_should_publish: ${{ steps.status.outputs.iridium_wasm_should_publish }}
+      iridium_server_test_support_should_publish: ${{ steps.status.outputs.iridium_server_test_support_should_publish }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Check crates.io status
+        id: status
+        run: node scripts/release-status.mjs
+
+  publish:
+    needs: detect
+    if: needs.detect.outputs.any_crates_should_publish == 'true'
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.detect.outputs.shared_version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish iridium_core
+        if: needs.detect.outputs.iridium_core_should_publish == 'true'
+        run: cargo publish -p iridium_core --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Wait for iridium_core
+        if: needs.detect.outputs.iridium_core_should_publish == 'true' && (needs.detect.outputs.iridium_server_should_publish == 'true' || needs.detect.outputs.iridium_wasm_should_publish == 'true' || needs.detect.outputs.iridium_server_test_support_should_publish == 'true')
+        run: node scripts/wait-for-crate.mjs iridium_core "$RELEASE_VERSION"
+
+      - name: Publish iridium_server
+        if: needs.detect.outputs.iridium_server_should_publish == 'true'
+        run: cargo publish -p iridium_server --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Wait for iridium_server
+        if: needs.detect.outputs.iridium_server_should_publish == 'true' && needs.detect.outputs.iridium_server_test_support_should_publish == 'true'
+        run: node scripts/wait-for-crate.mjs iridium_server "$RELEASE_VERSION"
+
+      - name: Publish iridium_wasm
+        if: needs.detect.outputs.iridium_wasm_should_publish == 'true'
+        run: cargo publish -p iridium_wasm --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Publish iridium_server_test_support
+        if: needs.detect.outputs.iridium_server_test_support_should_publish == 'true'
+        run: cargo publish -p iridium_server_test_support --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,15 +3,41 @@ name: Publish npm package
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "iridium-client-v*"
+    branches:
+      - main
 
 permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: publish-npm-main
+  cancel-in-progress: false
+
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      npm_local_version: ${{ steps.status.outputs.npm_local_version }}
+      npm_remote_version: ${{ steps.status.outputs.npm_remote_version }}
+      npm_should_publish: ${{ steps.status.outputs.npm_should_publish }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Check npm registry status
+        id: status
+        run: node scripts/release-status.mjs
+
   publish:
+    needs: detect
+    if: needs.detect.outputs.npm_should_publish == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -30,6 +56,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
@@ -41,6 +68,4 @@ jobs:
         run: npm run build
 
       - name: Publish package
-        run: npm publish --access public --provenance --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ""
+        run: npm publish --access public --ignore-scripts

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,0 +1,25 @@
+name: Version Sync Check
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Verify synchronized versions
+        run: node scripts/version-sync.mjs check

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -9,7 +9,7 @@ on:
       release_tag:
         description: Windows release tag to use for artifact names
         required: true
-        default: v0.1.0-windows.1
+        default: v0.1.2-windows.1
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,7 @@ cargo test -p iridium_server -- --ignored
 3. Add executor in `iridium_core/src/executor/`
 4. Update exports in `iridium_core/src/lib.rs`
 
+**Keep versions synchronized before commits:**
+1. Run `pwsh scripts/install-hooks.ps1` once per clone to enable the local pre-commit hook.
+2. The hook runs `scripts/version-sync.mjs bump` so npm and crate versions stay aligned automatically.
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "chrono",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_server"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_server_test_support"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "env_logger",
  "iridium_core",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_wasm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "console_error_panic_hook",
  "iridium_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_core"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "chrono",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_server"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_server_test_support"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "env_logger",
  "iridium_core",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "iridium_wasm"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "console_error_panic_hook",
  "iridium_core",

--- a/crates/iridium_core/Cargo.toml
+++ b/crates/iridium_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_core"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "SQL Server-compatible Rust engine core for Iridium SQL"
 license = "MIT"

--- a/crates/iridium_core/Cargo.toml
+++ b/crates/iridium_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_core"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 description = "SQL Server-compatible Rust engine core for Iridium SQL"
 license = "MIT"

--- a/crates/iridium_server/Cargo.toml
+++ b/crates/iridium_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_server"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 description = "TDS 7.4 server for Iridium SQL"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["tds", "sql-server", "database", "server"]
 categories = ["database", "network-programming"]
 
 [dependencies]
-iridium_core = { path = "../iridium_core", version = "0.1.0" }
+iridium_core = { path = "../iridium_core", version = "0.1.3" }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "macros", "sync"] }
 rustls = "0.23"
 rcgen = { version = "0.13", features = ["pem", "crypto"] }
@@ -39,4 +39,3 @@ path = "bin/main.rs"
 [[bin]]
 name = "compat-query"
 path = "bin/compat-query.rs"
-

--- a/crates/iridium_server/Cargo.toml
+++ b/crates/iridium_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_server"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "TDS 7.4 server for Iridium SQL"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["tds", "sql-server", "database", "server"]
 categories = ["database", "network-programming"]
 
 [dependencies]
-iridium_core = { path = "../iridium_core", version = "0.1.3" }
+iridium_core = { path = "../iridium_core", version = "0.1.4" }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "macros", "sync"] }
 rustls = "0.23"
 rcgen = { version = "0.13", features = ["pem", "crypto"] }

--- a/crates/iridium_server_test_support/Cargo.toml
+++ b/crates/iridium_server_test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_server_test_support"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Test support helpers for Iridium SQL server integration tests"
 license = "MIT"
@@ -10,8 +10,8 @@ keywords = ["sql-server", "tds", "tests"]
 categories = ["database", "development-tools::testing"]
 
 [dependencies]
-iridium_core = { path = "../iridium_core", version = "0.1.3" }
-iridium_server = { path = "../iridium_server", version = "0.1.3" }
+iridium_core = { path = "../iridium_core", version = "0.1.4" }
+iridium_server = { path = "../iridium_server", version = "0.1.4" }
 tiberius = { version = "0.11", default-features = false, features = ["tokio", "tds73", "chrono", "rustls"] }
 tokio = { version = "1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/crates/iridium_server_test_support/Cargo.toml
+++ b/crates/iridium_server_test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_server_test_support"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 description = "Test support helpers for Iridium SQL server integration tests"
 license = "MIT"
@@ -10,12 +10,10 @@ keywords = ["sql-server", "tds", "tests"]
 categories = ["database", "development-tools::testing"]
 
 [dependencies]
-iridium_core = { path = "../iridium_core", version = "0.1.0" }
-iridium_server = { path = "../iridium_server", version = "0.1.0" }
+iridium_core = { path = "../iridium_core", version = "0.1.3" }
+iridium_server = { path = "../iridium_server", version = "0.1.3" }
 tiberius = { version = "0.11", default-features = false, features = ["tokio", "tds73", "chrono", "rustls"] }
 tokio = { version = "1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 log = "0.4"
 env_logger = "0.11"
-
-

--- a/crates/iridium_wasm/Cargo.toml
+++ b/crates/iridium_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_wasm"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "WASM bindings for Iridium SQL"
 license = "MIT"
@@ -16,4 +16,4 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2"
 serde_json = "1"
 console_error_panic_hook = "0.1"
-iridium_core = { path = "../iridium_core", version = "0.1.3" }
+iridium_core = { path = "../iridium_core", version = "0.1.4" }

--- a/crates/iridium_wasm/Cargo.toml
+++ b/crates/iridium_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iridium_wasm"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 description = "WASM bindings for Iridium SQL"
 license = "MIT"
@@ -16,5 +16,4 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2"
 serde_json = "1"
 console_error_panic_hook = "0.1"
-iridium_core = { path = "../iridium_core", version = "0.1.0" }
-
+iridium_core = { path = "../iridium_core", version = "0.1.3" }

--- a/packages/iridium-client/package-lock.json
+++ b/packages/iridium-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@celsowm/iridium-sql-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@celsowm/iridium-sql-client",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "devDependencies": {
         "@types/node": "^22.15.29",
         "typescript": "^5.6.3"

--- a/packages/iridium-client/package-lock.json
+++ b/packages/iridium-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@celsowm/iridium-sql-client",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@celsowm/iridium-sql-client",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "devDependencies": {
         "@types/node": "^22.15.29",
         "typescript": "^5.6.3"

--- a/packages/iridium-client/package.json
+++ b/packages/iridium-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celsowm/iridium-sql-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/iridium-client/package.json
+++ b/packages/iridium-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celsowm/iridium-sql-client",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/iridium-playground/package.json
+++ b/packages/iridium-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iridium-sql/playground",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite"

--- a/packages/iridium-playground/package.json
+++ b/packages/iridium-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iridium-sql/playground",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite"
@@ -12,4 +12,3 @@
     "vite": "^5.4.10"
   }
 }
-

--- a/packages/iridium-tests/package.json
+++ b/packages/iridium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iridium-sql/tests",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "test": "vitest run"
@@ -12,4 +12,3 @@
     "vitest": "^2.1.3"
   }
 }
-

--- a/packages/iridium-tests/package.json
+++ b/packages/iridium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iridium-sql/tests",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "test": "vitest run"

--- a/scripts/install-hooks.ps1
+++ b/scripts/install-hooks.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+git config core.hooksPath .githooks
+Write-Host "Configured git hooks path to .githooks"

--- a/scripts/release-status.mjs
+++ b/scripts/release-status.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const npmPackage = {
+  key: "npm",
+  name: "@celsowm/iridium-sql-client",
+  manifest: "packages/iridium-client/package.json",
+  registry: "npm",
+};
+
+const crates = [
+  {
+    key: "iridium_core",
+    name: "iridium_core",
+    manifest: "crates/iridium_core/Cargo.toml",
+    registry: "crates",
+  },
+  {
+    key: "iridium_server",
+    name: "iridium_server",
+    manifest: "crates/iridium_server/Cargo.toml",
+    registry: "crates",
+  },
+  {
+    key: "iridium_wasm",
+    name: "iridium_wasm",
+    manifest: "crates/iridium_wasm/Cargo.toml",
+    registry: "crates",
+  },
+  {
+    key: "iridium_server_test_support",
+    name: "iridium_server_test_support",
+    manifest: "crates/iridium_server_test_support/Cargo.toml",
+    registry: "crates",
+  },
+];
+
+function parseSemver(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version ?? "");
+  if (!match) {
+    throw new Error(`Unsupported semantic version: ${version}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareSemver(left, right) {
+  const l = parseSemver(left);
+  const r = parseSemver(right);
+
+  if (l.major !== r.major) return l.major - r.major;
+  if (l.minor !== r.minor) return l.minor - r.minor;
+  return l.patch - r.patch;
+}
+
+async function readJson(relativePath) {
+  const filePath = path.join(repoRoot, relativePath);
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+async function readTomlVersion(relativePath) {
+  const filePath = path.join(repoRoot, relativePath);
+  const contents = await readFile(filePath, "utf8");
+  const match = contents.match(/^version = "([^"]+)"/m);
+
+  if (!match) {
+    throw new Error(`Could not read version from ${relativePath}`);
+  }
+
+  return match[1];
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "iridium-sql-release-status",
+    },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+async function fetchNpmVersion(packageName) {
+  const encodedName = packageName.replace("/", "%2f");
+  const body = await fetchJson(`https://registry.npmjs.org/${encodedName}/latest`);
+  return body?.version ?? null;
+}
+
+async function fetchCrateVersion(crateName) {
+  const body = await fetchJson(`https://crates.io/api/v1/crates/${crateName}`);
+  return body?.crate?.newest_version ?? null;
+}
+
+function asOutputValue(value) {
+  return value == null ? "" : String(value);
+}
+
+async function collectStatus() {
+  const npmManifest = await readJson(npmPackage.manifest);
+  const npmLocalVersion = npmManifest.version;
+  const npmRemoteVersion = await fetchNpmVersion(npmPackage.name);
+
+  const crateStatuses = [];
+  for (const crateDef of crates) {
+    const localVersion = await readTomlVersion(crateDef.manifest);
+    const remoteVersion = await fetchCrateVersion(crateDef.name);
+    crateStatuses.push({
+      ...crateDef,
+      localVersion,
+      remoteVersion,
+      shouldPublish:
+        remoteVersion == null || compareSemver(localVersion, remoteVersion) > 0,
+    });
+  }
+
+  return {
+    npm: {
+      ...npmPackage,
+      localVersion: npmLocalVersion,
+      remoteVersion: npmRemoteVersion,
+      shouldPublish:
+        npmRemoteVersion == null || compareSemver(npmLocalVersion, npmRemoteVersion) > 0,
+    },
+    crates: crateStatuses,
+  };
+}
+
+function writeGithubOutput(status) {
+  const lines = [
+    `npm_local_version=${asOutputValue(status.npm.localVersion)}`,
+    `npm_remote_version=${asOutputValue(status.npm.remoteVersion)}`,
+    `npm_should_publish=${status.npm.shouldPublish}`,
+    `shared_version=${asOutputValue(status.npm.localVersion)}`,
+    `any_crates_should_publish=${status.crates.some((crate) => crate.shouldPublish)}`,
+  ];
+
+  for (const crate of status.crates) {
+    lines.push(`${crate.key}_local_version=${asOutputValue(crate.localVersion)}`);
+    lines.push(`${crate.key}_remote_version=${asOutputValue(crate.remoteVersion)}`);
+    lines.push(`${crate.key}_should_publish=${crate.shouldPublish}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const status = await collectStatus();
+
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(process.env.GITHUB_OUTPUT, writeGithubOutput(status), "utf8");
+  } else {
+    console.log(JSON.stringify(status, null, 2));
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/version-sync.mjs
+++ b/scripts/version-sync.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const command = process.argv[2];
+
+if (!["bump", "check"].includes(command)) {
+  console.error("Usage: node scripts/version-sync.mjs <bump|check>");
+  process.exit(1);
+}
+
+const jsonFiles = [
+  "packages/iridium-client/package.json",
+  "packages/iridium-client/package-lock.json",
+  "packages/iridium-playground/package.json",
+  "packages/iridium-tests/package.json",
+];
+
+const cargoTomlFiles = [
+  {
+    path: "crates/iridium_core/Cargo.toml",
+    pathDependencies: [],
+  },
+  {
+    path: "crates/iridium_wasm/Cargo.toml",
+    pathDependencies: [{ name: "iridium_core", path: "../iridium_core" }],
+  },
+  {
+    path: "crates/iridium_server/Cargo.toml",
+    pathDependencies: [{ name: "iridium_core", path: "../iridium_core" }],
+  },
+  {
+    path: "crates/iridium_server_test_support/Cargo.toml",
+    pathDependencies: [
+      { name: "iridium_core", path: "../iridium_core" },
+      { name: "iridium_server", path: "../iridium_server" },
+    ],
+  },
+];
+
+const cargoLockPackages = [
+  "iridium_core",
+  "iridium_server",
+  "iridium_server_test_support",
+  "iridium_wasm",
+];
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseSemver(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (!match) {
+    throw new Error(`Unsupported semantic version: ${version}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareSemver(left, right) {
+  if (left.major !== right.major) return left.major - right.major;
+  if (left.minor !== right.minor) return left.minor - right.minor;
+  return left.patch - right.patch;
+}
+
+function incrementPatch(version) {
+  const parsed = parseSemver(version);
+  return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`;
+}
+
+async function readText(relativePath) {
+  return readFile(path.join(repoRoot, relativePath), "utf8");
+}
+
+async function writeText(relativePath, contents) {
+  await writeFile(path.join(repoRoot, relativePath), `${contents.replace(/\s*$/, "")}\n`, "utf8");
+}
+
+async function readJson(relativePath) {
+  return JSON.parse(await readText(relativePath));
+}
+
+async function writeJson(relativePath, data) {
+  await writeText(relativePath, JSON.stringify(data, null, 2));
+}
+
+function collectVersionsFromJson(relativePath, data) {
+  const versions = [];
+  if (typeof data.version === "string") {
+    versions.push({ source: `${relativePath}#version`, version: data.version });
+  }
+
+  if (relativePath.endsWith("package-lock.json")) {
+    const rootVersion = data.packages?.[""]?.version;
+    if (typeof rootVersion === "string") {
+      versions.push({ source: `${relativePath}#packages[""].version`, version: rootVersion });
+    }
+  }
+
+  return versions;
+}
+
+function collectVersionsFromCargoToml(relativePath, contents, pathDependencies) {
+  const versions = [];
+  const packageVersionMatch = contents.match(/^version = "([^"]+)"/m);
+  if (packageVersionMatch) {
+    versions.push({ source: `${relativePath}#package.version`, version: packageVersionMatch[1] });
+  }
+
+  for (const dependency of pathDependencies) {
+    const dependencyPattern = new RegExp(
+      `^${escapeRegex(dependency.name)} = \\{ path = "${escapeRegex(dependency.path)}", version = "([^"]+)" \\}$`,
+      "m",
+    );
+    const dependencyMatch = contents.match(dependencyPattern);
+    if (dependencyMatch) {
+      versions.push({
+        source: `${relativePath}#dependency.${dependency.name}`,
+        version: dependencyMatch[1],
+      });
+    }
+  }
+
+  return versions;
+}
+
+function collectVersionsFromCargoLock(contents) {
+  const versions = [];
+
+  for (const packageName of cargoLockPackages) {
+    const pattern = new RegExp(
+      `name = "${escapeRegex(packageName)}"\\r?\\nversion = "([^"]+)"`,
+      "m",
+    );
+    const match = contents.match(pattern);
+    if (match) {
+      versions.push({ source: `Cargo.lock#${packageName}`, version: match[1] });
+    }
+  }
+
+  return versions;
+}
+
+async function collectAllVersions() {
+  const versions = [];
+
+  for (const file of jsonFiles) {
+    const data = await readJson(file);
+    versions.push(...collectVersionsFromJson(file, data));
+  }
+
+  for (const file of cargoTomlFiles) {
+    const contents = await readText(file.path);
+    versions.push(...collectVersionsFromCargoToml(file.path, contents, file.pathDependencies));
+  }
+
+  const cargoLockContents = await readText("Cargo.lock");
+  versions.push(...collectVersionsFromCargoLock(cargoLockContents));
+
+  return versions;
+}
+
+function getUniqueVersions(versions) {
+  return [...new Set(versions.map((entry) => entry.version))];
+}
+
+async function updateJsonVersions(nextVersion) {
+  for (const file of jsonFiles) {
+    const data = await readJson(file);
+
+    if (typeof data.version === "string") {
+      data.version = nextVersion;
+    }
+
+    if (file.endsWith("package-lock.json") && data.packages?.[""]) {
+      data.packages[""].version = nextVersion;
+    }
+
+    await writeJson(file, data);
+  }
+}
+
+function updateCargoToml(contents, nextVersion, pathDependencies) {
+  let updated = contents.replace(/^version = "[^"]+"/m, `version = "${nextVersion}"`);
+
+  for (const dependency of pathDependencies) {
+    const dependencyPattern = new RegExp(
+      `^(${escapeRegex(dependency.name)} = \\{ path = "${escapeRegex(dependency.path)}", version = ")[^"]+(" \\})$`,
+      "m",
+    );
+    updated = updated.replace(dependencyPattern, `$1${nextVersion}$2`);
+  }
+
+  return updated;
+}
+
+function updateCargoLock(contents, nextVersion) {
+  let updated = contents;
+
+  for (const packageName of cargoLockPackages) {
+    const packagePattern = new RegExp(
+      `(name = "${escapeRegex(packageName)}"\\r?\\nversion = ")[^"]+(")`,
+      "m",
+    );
+    updated = updated.replace(packagePattern, `$1${nextVersion}$2`);
+  }
+
+  return updated;
+}
+
+async function writeCargoVersions(nextVersion) {
+  for (const file of cargoTomlFiles) {
+    const contents = await readText(file.path);
+    const updated = updateCargoToml(contents, nextVersion, file.pathDependencies);
+    await writeText(file.path, updated);
+  }
+
+  const cargoLockContents = await readText("Cargo.lock");
+  await writeText("Cargo.lock", updateCargoLock(cargoLockContents, nextVersion));
+}
+
+function printMismatch(versions) {
+  for (const entry of versions) {
+    console.error(`- ${entry.source}: ${entry.version}`);
+  }
+}
+
+async function stagePaths(paths) {
+  const result = spawnSync("git", ["add", "--", ...paths], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: false,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+async function main() {
+  const versions = await collectAllVersions();
+  const uniqueVersions = getUniqueVersions(versions);
+
+  if (command === "check") {
+    if (uniqueVersions.length > 1) {
+      console.error("Version mismatch detected across manifests:");
+      printMismatch(versions);
+      process.exit(1);
+    }
+
+    console.log(`Version sync ok: ${uniqueVersions[0]}`);
+    return;
+  }
+
+  const currentVersion = uniqueVersions
+    .map((version) => parseSemver(version))
+    .sort(compareSemver)
+    .at(-1);
+
+  if (!currentVersion) {
+    throw new Error("Could not determine a current version");
+  }
+
+  const nextVersion = incrementPatch(
+    `${currentVersion.major}.${currentVersion.minor}.${currentVersion.patch}`,
+  );
+
+  await updateJsonVersions(nextVersion);
+  await writeCargoVersions(nextVersion);
+  await stagePaths([
+    ...jsonFiles,
+    ...cargoTomlFiles.map((file) => file.path),
+    "Cargo.lock",
+  ]);
+
+  console.log(`Bumped synchronized version to ${nextVersion}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/wait-for-crate.mjs
+++ b/scripts/wait-for-crate.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const crateName = process.argv[2];
+const expectedVersion = process.argv[3];
+const maxAttempts = Number(process.env.MAX_ATTEMPTS ?? 30);
+const delayMs = Number(process.env.DELAY_MS ?? 10000);
+
+if (!crateName || !expectedVersion) {
+  console.error("Usage: node scripts/wait-for-crate.mjs <crate-name> <expected-version>");
+  process.exit(1);
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchLatestVersion() {
+  const response = await fetch(`https://crates.io/api/v1/crates/${crateName}`, {
+    headers: {
+      "User-Agent": "iridium-sql-wait-for-crate",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Could not query crates.io for ${crateName}: ${response.status}`);
+  }
+
+  const body = await response.json();
+  return body?.crate?.newest_version ?? null;
+}
+
+for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  const latestVersion = await fetchLatestVersion();
+  if (latestVersion === expectedVersion) {
+    console.log(`${crateName}@${expectedVersion} is visible on crates.io`);
+    process.exit(0);
+  }
+
+  console.log(
+    `Waiting for ${crateName}@${expectedVersion} on crates.io (attempt ${attempt}/${maxAttempts}, current: ${latestVersion ?? "missing"})`,
+  );
+  await sleep(delayMs);
+}
+
+console.error(`Timed out waiting for ${crateName}@${expectedVersion} on crates.io`);
+process.exit(1);


### PR DESCRIPTION
## Summary
- add a shared version sync script for npm and Cargo manifests
- wire a local pre-commit hook to bump patch versions before each commit
- publish npm automatically on pushes to `main` when the registry is behind
- publish crates automatically on pushes to `main` in dependency order, waiting for crates.io index visibility between dependent releases
- add CI checks so repeated pushes are idempotent and skip already-published versions

## Validation
- `node scripts/version-sync.mjs check`
- `node scripts/release-status.mjs`
- pushed branch `codex/version-sync`

## Operational note
- npm trusted publishing must be configured for `.github/workflows/publish-npm.yml`
- crates.io trusted publishing must be configured for `.github/workflows/publish-crates.yml`, or equivalent registry credentials must be provided