### PR TITLE
Refactor `execution_support` to resolve SRP violation in execution database mod

### DIFF
--- a/crates/iridium_core/src/executor/database/batch_runner.rs
+++ b/crates/iridium_core/src/executor/database/batch_runner.rs
@@ -11,120 +11,7 @@ use super::super::table_util::is_transaction_statement;
 use super::super::transaction_exec;
 use super::{EngineCatalog, EngineStorage};
 use super::dispatch::execute_non_transaction_statement;
-
-pub(crate) fn with_session<C, S, R, F>(
-    state: &SharedState<C, S>,
-    session_id: SessionId,
-    f: F,
-) -> Result<R, DbError>
-where
-    C: EngineCatalog,
-    S: EngineStorage,
-    F: FnOnce(&mut SessionRuntime<C, S>) -> Result<R, DbError>,
-{
-    let session_mutex = state
-        .sessions
-        .get(&session_id)
-        .ok_or_else(|| DbError::Execution(format!("session {} not found", session_id)))?;
-    let mut session = session_mutex.lock();
-    f(&mut session)
-}
-
-#[allow(deprecated)]
-#[allow(clippy::type_complexity)]
-pub(crate) fn build_execution_context<'a, C, S>(
-    session_id: SessionId,
-    session: &'a mut SessionRuntime<C, S>,
-    state: &SharedState<C, S>,
-) -> (
-    ExecutionContext<'a>,
-    &'a mut crate::executor::transaction::TransactionManager<
-        C,
-        S,
-        crate::executor::session::SessionSnapshot,
-    >,
-    &'a mut Box<dyn crate::executor::journal::Journal>,
-    &'a mut Option<crate::executor::locks::TxWorkspace<C, S>>,
-    &'a mut Box<dyn crate::executor::clock::Clock>,
-    &'a mut crate::executor::tooling::SessionOptions,
-)
-where
-    C: EngineCatalog,
-    S: EngineStorage,
-{
-    let dirty_buffer = if session.tx_manager.active.is_some() {
-        Some(state.dirty_buffer.clone())
-    } else {
-        None
-    };
-    let (
-        clock,
-        tx_manager,
-        journal,
-        variables,
-        identities,
-        tables,
-        cursors,
-        diagnostics,
-        workspace,
-        options,
-        random_state,
-        current_database,
-        original_database,
-        user,
-        app_name,
-        host_name,
-    ) = (
-        &mut session.clock,
-        &mut session.tx_manager,
-        &mut session.journal,
-        &mut session.variables,
-        &mut session.identities,
-        &mut session.tables,
-        &mut session.cursors,
-        &mut session.diagnostics,
-        &mut session.workspace,
-        &mut session.options,
-        &mut session.random_state,
-        &mut session.current_database,
-        &mut session.original_database,
-        &mut session.user,
-        &mut session.app_name,
-        &mut session.host_name,
-    );
-
-    let mut ctx = ExecutionContext::new(
-        variables,
-        &mut session.bulk_load_active,
-        &mut session.bulk_load_table,
-        &mut session.bulk_load_columns,
-        &mut session.bulk_load_received_metadata,
-        &mut identities.last_identity,
-        &mut identities.scope_stack,
-        &mut tables.temp_map,
-        &mut tables.var_map,
-        &mut tables.var_counter,
-        options.ansi_nulls,
-        options.datefirst,
-        random_state,
-        &mut cursors.map,
-        &mut cursors.fetch_status,
-        &mut cursors.next_cursor_handle,
-        &mut cursors.handle_map,
-        &mut diagnostics.print_output,
-        &mut session.context_info,
-        &mut session.session_context,
-        dirty_buffer,
-        session_id,
-        current_database.clone(),
-        original_database.clone(),
-        user.clone(),
-        app_name.clone(),
-        host_name.clone(),
-    );
-    ctx.options = options.clone();
-    (ctx, tx_manager, journal, workspace, clock, options)
-}
+use super::context_builder::build_execution_context;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn execute_stmt_loop<C, S, F>(
@@ -316,6 +203,8 @@ where
     );
     let current_database = ctx.metadata.database.clone();
 
+    // Scope cleanup always runs before error propagation — guarantees no leak
+    // even when the body returns Err (BREAK/CONTINUE/deadlock/etc).
     let dropped_physical = ctx.leave_scope_collect_table_vars();
     let tx_active = tx_manager.active.is_some();
     let workspace = workspace.as_mut();

--- a/crates/iridium_core/src/executor/database/context_builder.rs
+++ b/crates/iridium_core/src/executor/database/context_builder.rs
@@ -1,0 +1,100 @@
+use super::super::context::ExecutionContext;
+use super::super::locks::SessionId;
+use super::super::session::{SessionRuntime, SharedState};
+use super::{EngineCatalog, EngineStorage};
+
+#[allow(deprecated)]
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_execution_context<'a, C, S>(
+    session_id: SessionId,
+    session: &'a mut SessionRuntime<C, S>,
+    state: &SharedState<C, S>,
+) -> (
+    ExecutionContext<'a>,
+    &'a mut crate::executor::transaction::TransactionManager<
+        C,
+        S,
+        crate::executor::session::SessionSnapshot,
+    >,
+    &'a mut Box<dyn crate::executor::journal::Journal>,
+    &'a mut Option<crate::executor::locks::TxWorkspace<C, S>>,
+    &'a mut Box<dyn crate::executor::clock::Clock>,
+    &'a mut crate::executor::tooling::SessionOptions,
+)
+where
+    C: EngineCatalog,
+    S: EngineStorage,
+{
+    let dirty_buffer = if session.tx_manager.active.is_some() {
+        Some(state.dirty_buffer.clone())
+    } else {
+        None
+    };
+    let (
+        clock,
+        tx_manager,
+        journal,
+        variables,
+        identities,
+        tables,
+        cursors,
+        diagnostics,
+        workspace,
+        options,
+        random_state,
+        current_database,
+        original_database,
+        user,
+        app_name,
+        host_name,
+    ) = (
+        &mut session.clock,
+        &mut session.tx_manager,
+        &mut session.journal,
+        &mut session.variables,
+        &mut session.identities,
+        &mut session.tables,
+        &mut session.cursors,
+        &mut session.diagnostics,
+        &mut session.workspace,
+        &mut session.options,
+        &mut session.random_state,
+        &mut session.current_database,
+        &mut session.original_database,
+        &mut session.user,
+        &mut session.app_name,
+        &mut session.host_name,
+    );
+
+    let mut ctx = ExecutionContext::new(
+        variables,
+        &mut session.bulk_load_active,
+        &mut session.bulk_load_table,
+        &mut session.bulk_load_columns,
+        &mut session.bulk_load_received_metadata,
+        &mut identities.last_identity,
+        &mut identities.scope_stack,
+        &mut tables.temp_map,
+        &mut tables.var_map,
+        &mut tables.var_counter,
+        options.ansi_nulls,
+        options.datefirst,
+        random_state,
+        &mut cursors.map,
+        &mut cursors.fetch_status,
+        &mut cursors.next_cursor_handle,
+        &mut cursors.handle_map,
+        &mut diagnostics.print_output,
+        &mut session.context_info,
+        &mut session.session_context,
+        dirty_buffer,
+        session_id,
+        current_database.clone(),
+        original_database.clone(),
+        user.clone(),
+        app_name.clone(),
+        host_name.clone(),
+    );
+    ctx.options = options.clone();
+    (ctx, tx_manager, journal, workspace, clock, options)
+}

--- a/crates/iridium_core/src/executor/database/cursor_rpc.rs
+++ b/crates/iridium_core/src/executor/database/cursor_rpc.rs
@@ -19,7 +19,7 @@ where
     C: EngineCatalog,
     S: EngineStorage,
 {
-    super::execution_support::with_session(state, session_id, |session| {
+    super::session_access::with_session(state, session_id, |session| {
         let quoted_ident = session.options.quoted_identifier;
         let stmts = parse_batch_with_quoted_ident(sql, quoted_ident)?;
         let first_stmt = stmts
@@ -97,7 +97,7 @@ where
     C: EngineCatalog,
     S: EngineStorage,
 {
-    super::execution_support::with_session(state, session_id, |session| {
+    super::session_access::with_session(state, session_id, |session| {
         let cursor_name = session
             .cursors
             .handle_map
@@ -189,7 +189,7 @@ where
     C: EngineCatalog,
     S: EngineStorage,
 {
-    super::execution_support::with_session(state, session_id, |session| {
+    super::session_access::with_session(state, session_id, |session| {
         let cursor_name = session
             .cursors
             .handle_map
@@ -214,7 +214,7 @@ where
     C: EngineCatalog,
     S: EngineStorage,
 {
-    super::execution_support::with_session(state, session_id, |session| {
+    super::session_access::with_session(state, session_id, |session| {
         let cursor_name = session
             .cursors
             .handle_map
@@ -237,7 +237,7 @@ where
     C: EngineCatalog,
     S: EngineStorage,
 {
-    super::execution_support::with_session(state, session_id, |session| {
+    super::session_access::with_session(state, session_id, |session| {
         session.bulk_load_active = active;
         session.bulk_load_table = Some(table);
         session.bulk_load_columns = Some(columns);
@@ -259,7 +259,7 @@ where
     C: EngineCatalog,
     S: EngineStorage,
 {
-    super::execution_support::with_session(state, session_id, |session| {
+    super::session_access::with_session(state, session_id, |session| {
         Ok((
             session.bulk_load_active,
             session.bulk_load_table.clone(),

--- a/crates/iridium_core/src/executor/database/execution.rs
+++ b/crates/iridium_core/src/executor/database/execution.rs
@@ -14,7 +14,8 @@ use super::super::table_util::is_transaction_statement;
 use super::super::transaction_exec;
 use super::{CursorFetchResult, StatementExecutor};
 use super::{EngineCatalog, EngineStorage};
-use super::execution_support;
+use super::session_access;
+use super::batch_runner;
 use super::cursor_rpc;
 
 use super::dispatch::execute_non_transaction_statement;
@@ -29,8 +30,8 @@ where
         session_id: SessionId,
         stmt: Statement,
     ) -> Result<Option<QueryResult>, DbError> {
-        execution_support::with_session(&self.state, session_id, |session| {
-            execution_support::execute_single_statement(&self.state, session_id, session, stmt)
+        session_access::with_session(&self.state, session_id, |session| {
+            batch_runner::execute_single_statement(&self.state, session_id, session, stmt)
         })
     }
 
@@ -39,8 +40,8 @@ where
         session_id: SessionId,
         stmts: Vec<Statement>,
     ) -> Result<Option<QueryResult>, DbError> {
-        execution_support::with_session(&self.state, session_id, |session| {
-            execution_support::execute_batch_statements(&self.state, session_id, session, stmts)
+        session_access::with_session(&self.state, session_id, |session| {
+            batch_runner::execute_batch_statements(&self.state, session_id, session, stmts)
         })
     }
 
@@ -49,13 +50,13 @@ where
         session_id: SessionId,
         sql: &str,
     ) -> Result<Option<QueryResult>, DbError> {
-        let quoted_ident = execution_support::with_session(&self.state, session_id, |session| {
+        let quoted_ident = session_access::with_session(&self.state, session_id, |session| {
             Ok(session.options.quoted_identifier)
         })?;
 
         let stmts = parse_batch_with_quoted_ident(sql, quoted_ident)?;
-        execution_support::with_session(&self.state, session_id, |session| {
-            execution_support::execute_batch_statements(&self.state, session_id, session, stmts)
+        session_access::with_session(&self.state, session_id, |session| {
+            batch_runner::execute_batch_statements(&self.state, session_id, session, stmts)
         })
     }
 
@@ -64,13 +65,13 @@ where
         session_id: SessionId,
         sql: &str,
     ) -> Result<Vec<Option<QueryResult>>, DbError> {
-        let quoted_ident = execution_support::with_session(&self.state, session_id, |session| {
+        let quoted_ident = session_access::with_session(&self.state, session_id, |session| {
             Ok(session.options.quoted_identifier)
         })?;
 
         let stmts = parse_batch_with_quoted_ident(sql, quoted_ident)?;
-        execution_support::with_session(&self.state, session_id, |session| {
-            execution_support::execute_batch_statements_multi(
+        session_access::with_session(&self.state, session_id, |session| {
+            batch_runner::execute_batch_statements_multi(
                 &self.state,
                 session_id,
                 session,
@@ -87,7 +88,7 @@ where
         host_name: Option<String>,
         database: Option<String>,
     ) -> Result<(), DbError> {
-        execution_support::with_session(&self.state, session_id, |session| {
+        session_access::with_session(&self.state, session_id, |session| {
             session.user = user;
             session.app_name = app_name;
             session.host_name = host_name;
@@ -100,7 +101,7 @@ where
     }
 
     fn set_session_database(&self, session_id: SessionId, database: String) -> Result<(), DbError> {
-        execution_support::with_session(&self.state, session_id, |session| {
+        session_access::with_session(&self.state, session_id, |session| {
             session.current_database = database;
             Ok(())
         })

--- a/crates/iridium_core/src/executor/database/mod.rs
+++ b/crates/iridium_core/src/executor/database/mod.rs
@@ -5,7 +5,10 @@ pub(crate) mod dispatch_helpers;
 pub(crate) mod dispatch_paths;
 pub(crate) mod engine;
 pub(crate) mod execution;
-pub(crate) mod execution_support;
+pub(crate) mod session_access;
+pub(crate) mod context_builder;
+pub(crate) mod batch_runner;
+
 pub(crate) mod persistence;
 
 use crate::ast::{IsolationLevel, Statement};

--- a/crates/iridium_core/src/executor/database/session_access.rs
+++ b/crates/iridium_core/src/executor/database/session_access.rs
@@ -1,0 +1,22 @@
+use crate::error::DbError;
+use super::super::locks::SessionId;
+use super::super::session::{SessionRuntime, SharedState};
+use super::{EngineCatalog, EngineStorage};
+
+pub(crate) fn with_session<C, S, R, F>(
+    state: &SharedState<C, S>,
+    session_id: SessionId,
+    f: F,
+) -> Result<R, DbError>
+where
+    C: EngineCatalog,
+    S: EngineStorage,
+    F: FnOnce(&mut SessionRuntime<C, S>) -> Result<R, DbError>,
+{
+    let session_mutex = state
+        .sessions
+        .get(&session_id)
+        .ok_or_else(|| DbError::Execution(format!("session {} not found", session_id)))?;
+    let mut session = session_mutex.lock();
+    f(&mut session)
+}


### PR DESCRIPTION
This PR addresses an SRP violation described in `docs/srp-violations.md`. The helper module `execution_support.rs` mixed concerns like session access, context building, and batch execution loop logic. It has been removed and its functions extracted to three separate files:
- `session_access.rs` (`with_session`)
- `context_builder.rs` (`build_execution_context`)
- `batch_runner.rs` (`execute_batch_core_inner`, etc.)
The main `execution.rs` file now acts as a facade importing these focused modules.

---
*PR created automatically by Jules for task [16984110117171531336](https://jules.google.com/task/16984110117171531336) started by @celsowm*